### PR TITLE
Add documentation and make all stub sources structs

### DIFF
--- a/Sources/StubbornNetwork/Environment.swift
+++ b/Sources/StubbornNetwork/Environment.swift
@@ -7,36 +7,30 @@
 
 import Foundation
 
-enum Keys: String {
-    case testing = "TESTING"
+/// These keys are used by tests to setup the environment variables of the application under test.
+/// The values are read inside the application to identify the location of the current stub during test execution.
+enum EnvironmentVariableKeys: String {
     case stubName = "STUB_NAME"
     case stubPath = "STUB_PATH"
 }
 
-///
-/// An environment can be queried for whether or not the app has been launched in a testing environment.
-///
-/// Application logic can (carefully) take different code paths for testing purposes. For exampe, Xcode UI Tests
-/// should not run against the production backend - a testing environment might provide an alternate server
-/// for network requests or stubbornly stub requests.
-///
+/// An environment defines the location of a `StubSource`.
 struct Environment {
-    let testing: Bool
     let stubSourceName: String?
     let stubSourcePath: String?
 
+    /// The initializer takes a process info in order to read the environment variables
+    /// which define the location o the current stub source during test execution
+    /// - Parameter processInfo: The process info is setup by the test, using the `EnvironmentVariableKeys` to specify a path and a name of a stub source
     init(processInfo: ProcessInfo = ProcessInfo()) {
-        let testing = processInfo.environment[Keys.testing.rawValue] != nil
-        let stubSourceName = processInfo.environment[Keys.stubName.rawValue]
-        let stubSourcePath = processInfo.environment[Keys.stubPath.rawValue]
+        let stubSourceName = processInfo.environment[EnvironmentVariableKeys.stubName.rawValue]
+        let stubSourcePath = processInfo.environment[EnvironmentVariableKeys.stubPath.rawValue]
 
-        self.init(testing: testing,
-                  stubSourceName: stubSourceName,
+        self.init(stubSourceName: stubSourceName,
                   stubSourcePath: stubSourcePath)
     }
 
-    init(testing: Bool, stubSourceName: String? = nil, stubSourcePath: String? = nil) {
-        self.testing = testing
+    private init(stubSourceName: String? = nil, stubSourcePath: String? = nil) {
         self.stubSourceName = stubSourceName
         self.stubSourcePath = stubSourcePath
     }

--- a/Sources/StubbornNetwork/EphemeralStubSource.swift
+++ b/Sources/StubbornNetwork/EphemeralStubSource.swift
@@ -7,14 +7,18 @@
 
 import Foundation
 
-class EphemeralStubSource: StubSourceProtocol {
+/// This stub source only lives in memory. It is most useful for unit tests where a method
+/// is tested against a specific request.
+/// `EphemeralStubSource` is normally not used to stub a multitude of requests.
+struct EphemeralStubSource: StubSourceProtocol {
     var expectedDatas = [URLRequest: Data?]()
     var expectedResponses = [URLRequest: URLResponse?]()
     var expectedErrors = [URLRequest: Error?]()
+}
 
-    init() {}
-
-    func store(_ stub: RequestStub) {
+/// `EphemeralStubSource` conforms to `StubSourceProtocol`
+extension EphemeralStubSource {
+    mutating func store(_ stub: RequestStub) {
         if let data = stub.data {
             expectedDatas[stub.request] = data
         }

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -51,7 +51,7 @@ public struct StubbornNetwork {
     static func stubbed(withProcessInfo processInfo: ProcessInfo, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         /// TODO: Move this implementation to an internal static func on `URLSessionStub`
-        let env = Environment(processInfo: ProcessInfo())
+        let env = Environment(processInfo: processInfo)
         let name = env.stubSourceName
         let path = env.stubSourcePath
         assert(name != nil, "You have provided a process info but you are missing an environment variable called `\(EnvironmentVariableKeys.stubName)` that specifies the name of the current stub. Use the `stubbed(withConfiguration: .ephemeral)` if you are not intending to store stubs and keep them in memory instead.")

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -7,27 +7,28 @@ import Foundation
 /// can be used during tests to inject stubbed responses into your data structures
 /// where normally a `URLSession` would be used to make network requests.
 ///
-/// Stubbing your network can greatly improve flakiness in UI tests, is a common practice
+/// Stubbing your network can greatly improve flakiness in UI tests and is a common practice
 /// for unit tests. You can also use stubbed network responses for running SwiftUI Previews
-/// more efficiently
+/// more efficiently where the stubs act like a cache.
 public struct StubbornNetwork {
 
-    public static func stubbed(withProcessInfo processInfo: ProcessInfo, stub:((StubbornURLSession) -> Void)? = nil) -> URLSession {
-
-			/// TODO: Move this implementation to an internal static func on `URLSessionStub`
-        let env = Environment(processInfo: ProcessInfo())
-        let name = env.stubSourceName
-        let path = env.stubSourcePath
-        assert(name != nil, "You have provided a process info but you are missing an environment variable called `\(Keys.stubName)` that specifies the name of the current stub. Use the `stubbed(withConfiguration: .ephemeral)` if you are not intending to store stubs and keep them in memory instead.")
-        assert(path != nil, "You have provided a process info but you are missing an environment variable called `\(Keys.stubPath)` that specifies the path to the stub source. Use the `stubbed(withConfiguration: .ephemeral)` if you are not intending to store stubs and keep them in memory instead.")
-        return stubbed(withConfiguration: .persistent(name: name!, path: path!), stub: stub)
+    /// Create a stubbed `URLSession`. The current `ProcessInfo`'s environment variables need to be setup for The Stubborn Network to know where the source of the stubs it should use have been persisted to.
+    /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
+    public static func stubbed(_ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+        return stubbed(withProcessInfo: ProcessInfo(), stubbornURLSession)
     }
 
-    public static func stubbed(withConfiguration configuration: StubSourceConfiguration = .ephemeral, stub:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+    /// Create a stubbed `URLSession` that lives in memory only. The stubs of this `StubbornURLSession` are not persisted anywhere. This factory method is useful in unit tests.
+    /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
+    public static func ephemeralStub(_ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+        return stubbed(withConfiguration: .ephemeral, stubbornURLSession)
+    }
+
+    static func stubbed(withConfiguration configuration: StubSourceConfiguration = .ephemeral, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         let session: URLSessionStub
 
-			/// TODO: Move this implementation to an internal static func on `URLSessionStub`
+        /// TODO: Move this implementation to an internal static func on `URLSessionStub`
         switch configuration {
         case .ephemeral:
             session = URLSessionStub(configuration: .ephemeral, stubSource: EphemeralStubSource())
@@ -38,10 +39,23 @@ public struct StubbornNetwork {
             session = URLSessionStub(configuration: .ephemeral, stubSource: stubSource)
         }
 
-        if let stub = stub {
-            stub(session)
+        if let stubbornURLSession = stubbornURLSession {
+            stubbornURLSession(session)
         }
         return session
+    }
 
+    /// Create a stubbed `URLSession` by providing a `ProcessInfo` that contains information about the location of the source for the stubs
+    /// - Parameter processInfo: The process info that contains `EnvironmentVariableKeys` specifying the location of the stub source.
+    /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
+    static func stubbed(withProcessInfo processInfo: ProcessInfo, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+
+        /// TODO: Move this implementation to an internal static func on `URLSessionStub`
+        let env = Environment(processInfo: ProcessInfo())
+        let name = env.stubSourceName
+        let path = env.stubSourcePath
+        assert(name != nil, "You have provided a process info but you are missing an environment variable called `\(EnvironmentVariableKeys.stubName)` that specifies the name of the current stub. Use the `stubbed(withConfiguration: .ephemeral)` if you are not intending to store stubs and keep them in memory instead.")
+        assert(path != nil, "You have provided a process info but you are missing an environment variable called `\(EnvironmentVariableKeys.stubPath)` that specifies the path to the stub source. Use the `stubbed(withConfiguration: .ephemeral)` if you are not intending to store stubs and keep them in memory instead.")
+        return stubbed(withConfiguration: .persistent(name: name!, path: path!), stubbornURLSession)
     }
 }

--- a/Sources/StubbornNetwork/URLSessionStub.swift
+++ b/Sources/StubbornNetwork/URLSessionStub.swift
@@ -16,6 +16,10 @@ class URLSessionStub: URLSession, StubbornURLSession {
     var recordMode: RecordMode = .playback
     private let endToEndURLSession: URLSession
 
+    /// Initializes a URLSessionStub with a stub source and configures a `URLSession` for recording stubs.
+    /// - Parameter configuration: When no `endToEndURLSession` is present, this configuration will be used to create a `URLSession` for performing the actual network requests when recording stubs
+    /// - Parameter stubSource: A stub source to use for fetching and storing stubs
+    /// - Parameter endToEndURLSession: This `URLSession` can be passed in for making the actual network requests when reording new stubs
     init(configuration: URLSessionConfiguration, stubSource: StubSourceProtocol = EphemeralStubSource(), endToEndURLSession: URLSession? = nil) {
         self.endToEndURLSession = endToEndURLSession ?? URLSession(configuration: configuration)
         self.stubSource = stubSource

--- a/Tests/StubbornNetworkTests/EnvironmentTests.swift
+++ b/Tests/StubbornNetworkTests/EnvironmentTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
  `Environment` expects a `ProcessInfo` to derive information about the name and location of the stub source. The `ProcessInfoStub` subclass of `ProcessInfo` is used to stub values into the otherwise immutable `ProcessInfo` to be able to test for the location and name.
  */
-private final class ProcessInfoStub: ProcessInfo {
+final class ProcessInfoStub: ProcessInfo {
 
     let stubName: String?
     let stubPath: String?

--- a/Tests/StubbornNetworkTests/EnvironmentTests.swift
+++ b/Tests/StubbornNetworkTests/EnvironmentTests.swift
@@ -15,11 +15,9 @@ import XCTest
  */
 private final class ProcessInfoStub: ProcessInfo {
 
-    let testing: Bool
     let stubName: String?
     let stubPath: String?
-    init(testing: Bool = true, stubName: String? = nil, stubPath: String? = nil) {
-        self.testing = testing
+    init(stubName: String? = nil, stubPath: String? = nil) {
         self.stubName = stubName
         self.stubPath = stubPath
         super.init()
@@ -29,17 +27,12 @@ private final class ProcessInfoStub: ProcessInfo {
         get {
             var pairs: [String:String] = [:]
             if stubName != nil {
-                pairs[Keys.stubName.rawValue] = stubName
+                pairs[EnvironmentVariableKeys.stubName.rawValue] = stubName
             }
 
             if stubPath != nil {
-                pairs[Keys.stubPath.rawValue] = stubPath
+                pairs[EnvironmentVariableKeys.stubPath.rawValue] = stubPath
             }
-
-            if testing {
-                pairs[Keys.testing.rawValue] = "testing"
-            }
-
             return pairs
         }
     }
@@ -51,21 +44,11 @@ class EnvironmentTests: XCTestCase {
         let processInfo = ProcessInfoStub(stubName: "a stub source", stubPath: "127.0.0.1")
         let environment = Environment(processInfo: processInfo)
 
-        XCTAssertTrue(environment.testing)
         XCTAssertEqual(environment.stubSourceName, "a stub source")
-        XCTAssertNotNil(environment.stubSourcePath)
-    }
-
-    func testInitializesVariables() {
-        let environment = Environment(testing: true,
-                                      stubSourceName: "a name",
-                                      stubSourcePath: "127.0.0.1")
-        XCTAssertTrue(environment.testing)
-        XCTAssertNotNil(environment.stubSourceName)
         XCTAssertNotNil(environment.stubSourcePath)
     }
 
     static var allTests = [(
         "testInitializesWithProcessInfo", testInitializesWithProcessInfo),
-                           ("testInitializesVariables", testInitializesVariables)]
+    ]
 }

--- a/Tests/StubbornNetworkTests/EphemeralStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/EphemeralStubSourceTests.swift
@@ -23,7 +23,7 @@ class EphemeralStubSourceTests: XCTestCase {
 
         let url = URL(string: "127.0.0.1")!
 
-        let stubSource = EphemeralStubSource()
+        var stubSource = EphemeralStubSource()
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
+++ b/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
@@ -12,7 +12,7 @@ final class StubbornNetworkTests: XCTestCase {
 
     func testCallsClosureWithStub() {
         let exp = expectation(description: "Closure was called")
-        let _ = StubbornNetwork.stubbed(withConfiguration: .ephemeral, stub: { stub in
+        let _ = StubbornNetwork.stubbed(withConfiguration: .ephemeral,  { stub in
             exp.fulfill()
         })
         wait(for: [exp], timeout: 0.1)

--- a/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
+++ b/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
@@ -2,12 +2,28 @@ import XCTest
 @testable import StubbornNetwork
 
 final class StubbornNetworkTests: XCTestCase {
+
     func testEphemeralStubbedURLSessionNotNil() {
+        XCTAssertNotNil(StubbornNetwork.ephemeralStub())
+    }
+
+    func testStubbedURLSessionWithConfigurationNotNil() {
         XCTAssertNotNil(StubbornNetwork.stubbed(withConfiguration: .ephemeral))
     }
 
     func testPersistentStubbedURLSessionNotNil() {
-        XCTAssertNotNil(StubbornNetwork.stubbed(withConfiguration: .persistent(name: "Stub", path: "127.0.0.1")))
+        let testProcessInfo = ProcessInfo()
+        XCTAssertNotNil(StubbornNetwork.stubbed(withConfiguration: .persistent(
+            name: "Stub",
+            path: testProcessInfo.environment["XCTestConfigurationFilePath"]!)))
+    }
+
+    func testPersistentStubbedURLSessionFromProcessInfoNotNil() {
+        let testProcessInfo = ProcessInfo()
+
+        let processInfo = ProcessInfoStub(stubName: "Stub", stubPath: testProcessInfo.environment["XCTestConfigurationFilePath"]!)
+
+        XCTAssertNotNil(StubbornNetwork.stubbed(withProcessInfo: processInfo))
     }
 
     func testCallsClosureWithStub() {


### PR DESCRIPTION
- there is plenty of documentation missing, this adds some
- all `StubSources`  are now structs