### PR TITLE
Add initializer for name and path to StubSourceLocation

### DIFF
--- a/Sources/StubbornNetwork/StubSourceConfiguration.swift
+++ b/Sources/StubbornNetwork/StubSourceConfiguration.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-/// StubSourceConfiguration defines the `URLSessionStub`s’ lifetime. They can either be ephemeral or they can be persisted on disk.
+/// `StubSourceConfiguration` defines the `URLSessionStub`s’ lifetime.
+///
+/// Configurations can either be ephemeral or they can be persisted on disk.
 /// When persisting a stub source to disk the location for the source needs to be provided.
 enum StubSourceConfiguration {
     case ephemeral

--- a/Sources/StubbornNetwork/StubSourceConfiguration.swift
+++ b/Sources/StubbornNetwork/StubSourceConfiguration.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// StubSourceConfiguration defines the `URLSessionStub`s’ lifetime. They can either be ephemeral or they can be persisted on disk.
 /// When persisting a stub source to disk the location for the source needs to be provided.
-public enum StubSourceConfiguration {
+enum StubSourceConfiguration {
     case ephemeral
     case persistent(location: StubSourceLocation)
 }

--- a/Sources/StubbornNetwork/StubSourceLocation.swift
+++ b/Sources/StubbornNetwork/StubSourceLocation.swift
@@ -15,14 +15,14 @@ public enum EnvironmentVariableKeys: String {
 }
 
 /// A `StubSourceLocation` defines where to find a `StubSource`.
-public struct StubSourceLocation {
+struct StubSourceLocation {
     let stubSourceName: String
     let stubSourcePath: String
 
     /// The initializer takes a process info in order to read the environment variables
     /// which define the path and name of the current stub source during test execution
     /// - Parameter processInfo: The process info is setup by the test, using the `EnvironmentVariableKeys` to specify a path and a name of a stub source
-    public init(processInfo: ProcessInfo = ProcessInfo()) {
+    init(processInfo: ProcessInfo = ProcessInfo()) {
         let name = processInfo.environment[EnvironmentVariableKeys.stubName.rawValue]
 
         assert(name != nil, "A stub source must have a name. Specify one in the environment variables with the key `\(EnvironmentVariableKeys.stubName.rawValue)`")
@@ -32,7 +32,7 @@ public struct StubSourceLocation {
         self.init(name: name!, path: path!)
     }
 
-    public init(name: String, path: String) {
+    init(name: String, path: String) {
         stubSourceName = name
         stubSourcePath = path
     }

--- a/Sources/StubbornNetwork/StubSourceLocation.swift
+++ b/Sources/StubbornNetwork/StubSourceLocation.swift
@@ -26,10 +26,14 @@ public struct StubSourceLocation {
         let name = processInfo.environment[EnvironmentVariableKeys.stubName.rawValue]
 
         assert(name != nil, "A stub source must have a name. Specify one in the environment variables with the key `\(EnvironmentVariableKeys.stubName.rawValue)`")
-        stubSourceName = name!
-
         let path = processInfo.environment[EnvironmentVariableKeys.stubPath.rawValue]
         assert(path != nil, "A stub source must have a path. Specify one in the environment variables with the key `\(EnvironmentVariableKeys.stubPath.rawValue)`")
-        stubSourcePath = path!
+
+        self.init(name: name!, path: path!)
+    }
+
+    init(name: String, path: String) {
+        stubSourceName = name
+        stubSourcePath = path
     }
 }

--- a/Sources/StubbornNetwork/StubSourceLocation.swift
+++ b/Sources/StubbornNetwork/StubSourceLocation.swift
@@ -22,7 +22,7 @@ public struct StubSourceLocation {
     /// The initializer takes a process info in order to read the environment variables
     /// which define the path and name of the current stub source during test execution
     /// - Parameter processInfo: The process info is setup by the test, using the `EnvironmentVariableKeys` to specify a path and a name of a stub source
-    init(processInfo: ProcessInfo = ProcessInfo()) {
+    public init(processInfo: ProcessInfo = ProcessInfo()) {
         let name = processInfo.environment[EnvironmentVariableKeys.stubName.rawValue]
 
         assert(name != nil, "A stub source must have a name. Specify one in the environment variables with the key `\(EnvironmentVariableKeys.stubName.rawValue)`")
@@ -32,7 +32,7 @@ public struct StubSourceLocation {
         self.init(name: name!, path: path!)
     }
 
-    init(name: String, path: String) {
+    public init(name: String, path: String) {
         stubSourceName = name
         stubSourcePath = path
     }

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -21,7 +21,7 @@ public struct StubbornNetwork {
     /// Create a stubbed `URLSession` by providing a `ProcessInfo` that contains information about the location of the source for the stubs
     /// - Parameter processInfo: The process info that contains `EnvironmentVariableKeys` specifying the location of the stub source.
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
-    public static func persistedStubbedURLSession(withProcessInfo processInfo: ProcessInfo, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+    public static func persistedStubbedURLSession(withProcessInfo processInfo: ProcessInfo = ProcessInfo(), _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         /// TODO: Move this implementation to an internal static func on `URLSessionStub`
         let location = StubSourceLocation(processInfo: processInfo)

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -10,13 +10,22 @@ import Foundation
 /// Stubbing your network can greatly improve flakiness in UI tests and is a common practice
 /// for unit tests. You can also use stubbed network responses for running SwiftUI Previews
 /// more efficiently where the stubs act like a cache.
-public struct StubbornNetwork {
+public struct StubbornNetwork {}
 
-    /// Shorthand for a `StubbornURLSession` with a `.ephemeral` configutation. Creates a stubbed `URLSession` that lives in memory only. The stubs of this `StubbornURLSession` are not persisted anywhere. This factory method is useful in unit tests.
+// MARK: Ephemeral stubbed URLSessions
+
+extension StubbornNetwork {
+
+    /// Creates a stubbed `URLSession` that lives in memory only. The stubs of this `StubbornURLSession` are not persisted anywhere. This factory method is useful in unit tests.
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
     public static func ephemeralStubbedURLSession(_ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
         return stubbed(withConfiguration: .ephemeral, stubbornURLSession)
     }
+}
+
+// MARK: Persisted stubbed URLSessions
+
+extension StubbornNetwork {
 
     /// Create a stubbed `URLSession` by providing a `ProcessInfo` that contains information about the location of the source for the stubs
     /// - Parameter processInfo: The process info that contains `EnvironmentVariableKeys` specifying the location of the stub source.
@@ -28,13 +37,21 @@ public struct StubbornNetwork {
         return stubbed(withConfiguration: .persistent(location: location), stubbornURLSession)
     }
 
-    static func persistedStubbedURLSession(withName name: String, path: String, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+    /// Create a stubbed `URLSession` by providing a name and a path to the source for the stubs to use.
+    /// - Parameter name: The file name of the `StubSource`
+    /// - Parameter path: The path to the `StubSource`
+    /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
+    public static func persistedStubbedURLSession(withName name: String, path: String, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         /// TODO: Move this implementation to an internal static func on `URLSessionStub`
         let location = StubSourceLocation(name: name, path: path)
         return stubbed(withConfiguration: .persistent(location: location), stubbornURLSession)
     }
+}
 
+// MARK: Module Internal Implementation Details
+
+extension StubbornNetwork {
     ///    Creates a stubbed `URLSession` with a configuration.
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
     /// - Parameter configuration

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 ///
-/// The Stubborn Network - a Swifty and clean stubbing machine.
+/// The Stubborn Network - a Swifty and Clean Stubbing Machine.
 ///
 /// The StubbornNetwork provides stubbed `URLSession`s. These `StubbornURLSession`s
-/// can be used during tests to inject stubbed responses into your data structures
-/// where normally a `URLSession` would be used to make network requests.
+/// can be used during tests to inject stubbed responses into your data structures where normally a
+/// `URLSession` would be used to make network requests.
 ///
 /// Stubbing your network can greatly improve flakiness in UI tests and is a common practice
-/// for unit tests. You can also use stubbed network responses for running SwiftUI Previews
+/// for unit tests. You can also use The Stubborn Network for running SwiftUI Previews
 /// more efficiently where the stubs act like a cache.
 public struct StubbornNetwork {}
 
@@ -16,32 +16,39 @@ public struct StubbornNetwork {}
 
 extension StubbornNetwork {
 
-    /// Creates a stubbed `URLSession` that lives in memory only. The stubs of this `StubbornURLSession` are not persisted anywhere. This factory method is useful in unit tests.
+    /// Make a stubbed `URLSession` that is ephemeral.
+    ///
+    /// The stubs of this `StubbornURLSession` are not persisted anywhere. This factory method is useful in unit tests.
+    ///
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
-    public static func ephemeralStubbedURLSession(_ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+    public static func makeEphemeralSession(_ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
         return stubbed(withConfiguration: .ephemeral, stubbornURLSession)
     }
 }
 
-// MARK: Persisted stubbed URLSessions
+// MARK: Persistent stubbed URLSessions
 
 extension StubbornNetwork {
 
-    /// Create a stubbed `URLSession` by providing a `ProcessInfo` that contains information about the location of the source for the stubs
+    /// Make a stubbed `URLSession` by providing a `ProcessInfo`.
+    ///
+    /// The `ProcessInfo` contains information about the location of the source for the stubs.
+    ///
     /// - Parameter processInfo: The process info that contains `EnvironmentVariableKeys` specifying the location of the stub source.
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
-    public static func persistedStubbedURLSession(withProcessInfo processInfo: ProcessInfo = ProcessInfo(), _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+    public static func makePersistentSession(withProcessInfo processInfo: ProcessInfo = ProcessInfo(), _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         /// TODO: Move this implementation to an internal static func on `URLSessionStub`
         let location = StubSourceLocation(processInfo: processInfo)
         return stubbed(withConfiguration: .persistent(location: location), stubbornURLSession)
     }
 
-    /// Create a stubbed `URLSession` by providing a name and a path to the source for the stubs to use.
+    /// Make a stubbed `URLSession` by providing a name and a path to the source for the stubs to use.
+    ///
     /// - Parameter name: The file name of the `StubSource`
     /// - Parameter path: The path to the `StubSource`
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
-    public static func persistedStubbedURLSession(withName name: String, path: String, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
+    public static func makePersistentSession(withName name: String, path: String, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         /// TODO: Move this implementation to an internal static func on `URLSessionStub`
         let location = StubSourceLocation(name: name, path: path)
@@ -52,9 +59,11 @@ extension StubbornNetwork {
 // MARK: Module Internal Implementation Details
 
 extension StubbornNetwork {
-    ///    Creates a stubbed `URLSession` with a configuration.
+
+    /// Make a stubbed `URLSession` with a `StubSourceConfiguration`.
+    ///
+    /// - Parameter configuration: The configuration of the stub source of the stubbed `URLSession`
     /// - Parameter stubbornURLSession: The mutable `StubbornURLSession`. Use the closure's parameter to modify the record mode of the `StubbornURLSession` or to stub requests.
-    /// - Parameter configuration
     static func stubbed(withConfiguration configuration: StubSourceConfiguration = .ephemeral, _ stubbornURLSession:((StubbornURLSession) -> Void)? = nil) -> URLSession {
 
         let session: URLSessionStub

--- a/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
+++ b/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class StubbornNetworkTests: XCTestCase {
 
     func testEphemeralStubbedURLSessionNotNil() {
-        XCTAssertNotNil(StubbornNetwork.ephemeralStubbedURLSession())
+        XCTAssertNotNil(StubbornNetwork.makeEphemeralSession())
     }
 
     func testStubbedURLSessionWithConfigurationNotNil() {
@@ -29,13 +29,13 @@ final class StubbornNetworkTests: XCTestCase {
 
         let processInfo = ProcessInfoStub(stubName: "Stub", stubPath: testProcessInfo.environment["XCTestConfigurationFilePath"]!)
 
-        XCTAssertNotNil(StubbornNetwork.persistedStubbedURLSession(withProcessInfo: processInfo))
+        XCTAssertNotNil(StubbornNetwork.makePersistentSession(withProcessInfo: processInfo))
     }
 
     func testPersistentStubbedURLSessionWithNameAndPathNotNil() {
         let testProcessInfo = ProcessInfo()
 
-        XCTAssertNotNil(StubbornNetwork.persistedStubbedURLSession(
+        XCTAssertNotNil(StubbornNetwork.makePersistentSession(
             withName: "Stub",
             path: testProcessInfo.environment["XCTestConfigurationFilePath"]!)
         )

--- a/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
+++ b/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class StubbornNetworkTests: XCTestCase {
 
     func testEphemeralStubbedURLSessionNotNil() {
-        XCTAssertNotNil(StubbornNetwork.ephemeralStub())
+        XCTAssertNotNil(StubbornNetwork.ephemeralStubbedURLSession())
     }
 
     func testStubbedURLSessionWithConfigurationNotNil() {
@@ -19,7 +19,9 @@ final class StubbornNetworkTests: XCTestCase {
 
         let location = StubSourceLocation(processInfo: processInfo)
 
-        XCTAssertNotNil(StubbornNetwork.stubbed(withConfiguration: .persistent(location: location)))
+        XCTAssertNotNil(StubbornNetwork.stubbed(
+            withConfiguration: .persistent(location: location))
+        )
     }
 
     func testPersistentStubbedURLSessionFromProcessInfoNotNil() {
@@ -27,7 +29,16 @@ final class StubbornNetworkTests: XCTestCase {
 
         let processInfo = ProcessInfoStub(stubName: "Stub", stubPath: testProcessInfo.environment["XCTestConfigurationFilePath"]!)
 
-        XCTAssertNotNil(StubbornNetwork.stubbed(withProcessInfo: processInfo))
+        XCTAssertNotNil(StubbornNetwork.persistedStubbedURLSession(withProcessInfo: processInfo))
+    }
+
+    func testPersistentStubbedURLSessionWithNameAndPathNotNil() {
+        let testProcessInfo = ProcessInfo()
+
+        XCTAssertNotNil(StubbornNetwork.persistedStubbedURLSession(
+            withName: "Stub",
+            path: testProcessInfo.environment["XCTestConfigurationFilePath"]!)
+        )
     }
 
     func testCallsClosureWithStub() {


### PR DESCRIPTION
Make API more concise and adopt Swift style guide.