### PR TITLE
Compare headers lowercase. Fixes #15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode11.2
+osx_image: xcode11
 jobs:
   include:
     - stage: "Test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode11
+osx_image: xcode11.2
 jobs:
   include:
     - stage: "Test"

--- a/Sources/StubbornNetwork/PersistentStubSource.swift
+++ b/Sources/StubbornNetwork/PersistentStubSource.swift
@@ -103,22 +103,26 @@ extension PersistentStubSource {
 extension URLRequest {
     func matches() -> ((RequestStub) -> Bool) {
         let closure = { (requestStub: RequestStub) -> Bool in
-            let sortedA = self.allHTTPHeaderFields?.map({ (key, value) -> String in
-                return key.lowercased() + value
-            }).sorted(by: { (a, b) -> Bool in
-                return a < b
-            })
-
-            let sortedB = requestStub.request.allHTTPHeaderFields?.map({ (key, value) -> String in
-                return key.lowercased() + value
-            }).sorted(by: { (a, b) -> Bool in
-                return a < b
-            })
-
-            return self.url == requestStub.request.url &&
-                self.httpMethod == requestStub.request.httpMethod &&
-                sortedA == sortedB
+            return self.matches(request: requestStub.request)
         }
         return closure
+    }
+
+    func matches(request other: URLRequest) -> Bool {
+        let sortedA = self.allHTTPHeaderFields?.map({ (key, value) -> String in
+            return key.lowercased() + value
+        }).sorted(by: { (headerA, headerB) -> Bool in
+            return headerA < headerB
+        })
+
+        let sortedB = other.allHTTPHeaderFields?.map({ (key, value) -> String in
+            return key.lowercased() + value
+        }).sorted(by: { (headerA, headerB) -> Bool in
+            return headerA < headerB
+        })
+
+        return self.url == other.url &&
+            self.httpMethod == other.httpMethod &&
+            sortedA == sortedB
     }
 }

--- a/Sources/StubbornNetwork/PersistentStubSource.swift
+++ b/Sources/StubbornNetwork/PersistentStubSource.swift
@@ -104,13 +104,13 @@ extension URLRequest {
     func matches() -> ((RequestStub) -> Bool) {
         let closure = { (requestStub: RequestStub) -> Bool in
             let sortedA = self.allHTTPHeaderFields?.map({ (key, value) -> String in
-                return key + value
+                return key.lowercased() + value
             }).sorted(by: { (a, b) -> Bool in
                 return a < b
             })
 
             let sortedB = requestStub.request.allHTTPHeaderFields?.map({ (key, value) -> String in
-                return key + value
+                return key.lowercased() + value
             }).sorted(by: { (a, b) -> Bool in
                 return a < b
             })

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -18,4 +18,39 @@ class URLRequestMatcherTests: XCTestCase {
 
         XCTAssertTrue(requestWithCapitalHeader.matches(request: requestWithLowercaseHeader))
     }
+
+    func testHeaderDuplicateMismatches() throws {
+        var requestWithDuplicatedHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithDuplicatedHeader.setValue("alphabet", forHTTPHeaderField: "ABC")
+        requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "ABC")
+
+        var requestWithSingleHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithSingleHeader.setValue("alphabet", forHTTPHeaderField: "abc")
+
+        XCTAssertFalse(requestWithDuplicatedHeader.matches(request: requestWithSingleHeader))
+    }
+
+    func testHeaderDuplicateMatches() throws {
+        var requestWithDuplicatedHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithDuplicatedHeader.addValue("alphabet", forHTTPHeaderField: "ABC")
+        requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "ABC")
+
+        var requestWithDuplicatedLowercaseHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithDuplicatedLowercaseHeader.addValue("alphabet", forHTTPHeaderField: "abc")
+        requestWithDuplicatedLowercaseHeader.addValue("алфавит", forHTTPHeaderField: "abc")
+
+        XCTAssertTrue(requestWithDuplicatedHeader.matches(request: requestWithDuplicatedLowercaseHeader))
+    }
+
+    func testHeaderOrderMismatches() throws {
+        var requestWithDuplicatedHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithDuplicatedHeader.addValue("alphabet", forHTTPHeaderField: "abc")
+        requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "abc")
+
+        var requestWithDuplicatedHeaderDifferentOrder = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithDuplicatedHeaderDifferentOrder.addValue("алфавит", forHTTPHeaderField: "abc")
+        requestWithDuplicatedHeaderDifferentOrder.addValue("alphabet", forHTTPHeaderField: "abc")
+
+        XCTAssertFalse(requestWithDuplicatedHeader.matches(request: requestWithDuplicatedHeaderDifferentOrder))
+    }
 }

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -47,10 +47,10 @@ class URLRequestMatcherTests: XCTestCase {
         requestWithDuplicatedHeader.addValue("alphabet", forHTTPHeaderField: "abc")
         requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "abc")
 
-        var requestWithDuplicatedHeaderDifferentOrder = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
-        requestWithDuplicatedHeaderDifferentOrder.addValue("алфавит", forHTTPHeaderField: "abc")
-        requestWithDuplicatedHeaderDifferentOrder.addValue("alphabet", forHTTPHeaderField: "abc")
+        var requestWithDuplicatedHeaderOtherOrder = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithDuplicatedHeaderOtherOrder.addValue("алфавит", forHTTPHeaderField: "abc")
+        requestWithDuplicatedHeaderOtherOrder.addValue("alphabet", forHTTPHeaderField: "abc")
 
-        XCTAssertFalse(requestWithDuplicatedHeader.matches(request: requestWithDuplicatedHeaderDifferentOrder))
+        XCTAssertFalse(requestWithDuplicatedHeader.matches(request: requestWithDuplicatedHeaderOtherOrder))
     }
 }

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -1,0 +1,21 @@
+//
+//  URLRequestMatcherTests.swift
+//  
+//
+//  Created by Martin Kim Dung-Pham on 17.10.19.
+//
+
+import XCTest
+@testable import StubbornNetwork
+
+class URLRequestMatcherTests: XCTestCase {
+    func testMatchesRequestHeadersCaseSensitively() throws {
+        var requestWithCapitalHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithCapitalHeader.setValue("alphabet", forHTTPHeaderField: "ABC")
+
+        var requestWithLowercaseHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        requestWithLowercaseHeader.setValue("alphabet", forHTTPHeaderField: "abc")
+
+        XCTAssertTrue(requestWithCapitalHeader.matches(request: requestWithLowercaseHeader))
+    }
+}

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -9,45 +9,45 @@ import XCTest
 @testable import StubbornNetwork
 
 class URLRequestMatcherTests: XCTestCase {
-    func testMatchesRequestHeadersCaseSensitively() throws {
-        var requestWithCapitalHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+    func testMatchesRequestHeadersCaseSensitively() {
+        var requestWithCapitalHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithCapitalHeader.setValue("alphabet", forHTTPHeaderField: "ABC")
 
-        var requestWithLowercaseHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        var requestWithLowercaseHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithLowercaseHeader.setValue("alphabet", forHTTPHeaderField: "abc")
 
         XCTAssertTrue(requestWithCapitalHeader.matches(request: requestWithLowercaseHeader))
     }
 
-    func testHeaderDuplicateMismatches() throws {
-        var requestWithDuplicatedHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+    func testHeaderDuplicateMismatches() {
+        var requestWithDuplicatedHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithDuplicatedHeader.setValue("alphabet", forHTTPHeaderField: "ABC")
         requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "ABC")
 
-        var requestWithSingleHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        var requestWithSingleHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithSingleHeader.setValue("alphabet", forHTTPHeaderField: "abc")
 
         XCTAssertFalse(requestWithDuplicatedHeader.matches(request: requestWithSingleHeader))
     }
 
-    func testHeaderDuplicateMatches() throws {
-        var requestWithDuplicatedHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+    func testHeaderDuplicateMatches() {
+        var requestWithDuplicatedHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithDuplicatedHeader.addValue("alphabet", forHTTPHeaderField: "ABC")
         requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "ABC")
 
-        var requestWithDuplicatedLowercaseHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        var requestWithDuplicatedLowercaseHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithDuplicatedLowercaseHeader.addValue("alphabet", forHTTPHeaderField: "abc")
         requestWithDuplicatedLowercaseHeader.addValue("алфавит", forHTTPHeaderField: "abc")
 
         XCTAssertTrue(requestWithDuplicatedHeader.matches(request: requestWithDuplicatedLowercaseHeader))
     }
 
-    func testHeaderOrderMismatches() throws {
-        var requestWithDuplicatedHeader = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+    func testHeaderOrderMismatches() {
+        var requestWithDuplicatedHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithDuplicatedHeader.addValue("alphabet", forHTTPHeaderField: "abc")
         requestWithDuplicatedHeader.addValue("алфавит", forHTTPHeaderField: "abc")
 
-        var requestWithDuplicatedHeaderOtherOrder = URLRequest(url: try XCTUnwrap(URL(string: "127.0.0.1")))
+        var requestWithDuplicatedHeaderOtherOrder = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithDuplicatedHeaderOtherOrder.addValue("алфавит", forHTTPHeaderField: "abc")
         requestWithDuplicatedHeaderOtherOrder.addValue("alphabet", forHTTPHeaderField: "abc")
 


### PR DESCRIPTION
Fixes #15 by

- making `URLRequest` header matching case insensitive
- make `URLRequest` matching easier to test
- add explicit tests for the matching