### PR TITLE
Improve Local Test Execution Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,28 +127,8 @@ static var previews: some View {
 </p>
 </details>
 
-## Stub structure
+## Contribute
 
-The stubs are stored as plain json to make the behaviour of the stubs transparent.
+### Run Tests
 
-<details><summary>Stub Source JSON Example</summary>
-```json
-[{
-    "request": {
-        "url": "https://api.abc.com",
-        "headerFields": [
-            "Accept-Encoding[:::]br, gzip, deflate"
-        ],
-        "method": "POST"
-    },
-    "data": "YWJj",
-    "response": {
-        "statusCode": 200,
-        "headerFields": [
-            "Content-Type[:::]text\/xml; charset=utf-8"
-        ]
-    }
-}]
-```
-</p>
-</details>
+You can run tests either from within Xcode (`cmd+U`) or from the command line: `export STUB_DIR='./stubs' && swift test`.

--- a/Tests/StubbornNetworkTests/PersistentStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/PersistentStubSourceTests.swift
@@ -50,7 +50,7 @@ class StubSourceTests: XCTestCase {
     func testDataTaskStub() {
         let asyncExpectation = expectation(description: "Wait for async completion")
 
-        let url = URL(string: "\(stubSourceUrl.absoluteString)/123")!
+        let url = URL(string: "\(stubSourceUrl.path)/123")!
 
         var stubSource = PersistentStubSource(path: url)
 

--- a/Tests/StubbornNetworkTests/PersistentStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/PersistentStubSourceTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 class StubSourceTests: XCTestCase {
 
-    func testPath() {
-        let url = URL(string: "127.0.0.1")!
+    var stubSourceUrl = TestHelper.testingStubSourceUrl()
 
-        let stubSource = PersistentStubSource(name: "a name", path: url)
-        XCTAssertEqual(stubSource.path.absoluteString, "127.0.0.1/a_name.json")
+    func testPath() {
+        let stubSource = PersistentStubSource(name: "a name", path: stubSourceUrl)
+        XCTAssertEqual(stubSource.path.absoluteString, "\(stubSourceUrl.path)/a_name.json")
     }
 
     func testLoadsStubForRequest() {
@@ -50,7 +50,7 @@ class StubSourceTests: XCTestCase {
     func testDataTaskStub() {
         let asyncExpectation = expectation(description: "Wait for async completion")
 
-        let url = URL(string: "127.0.0.1/123")!
+        let url = URL(string: "\(stubSourceUrl.absoluteString)/123")!
 
         var stubSource = PersistentStubSource(path: url)
 

--- a/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
+++ b/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
@@ -8,14 +8,7 @@ final class StubbornNetworkTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let testProcessInfo = ProcessInfo()
-
-        let travisBuildDirectory = testProcessInfo.environment["TRAVIS_BUILD_DIR"]
-        if let directoryPath = travisBuildDirectory {
-            buildDirectory = directoryPath
-        } else {
-            buildDirectory = testProcessInfo.environment["XCTestConfigurationFilePath"]!
-        }
+        buildDirectory = TestHelper.testingStubSourcePath()
     }
 
     func testEphemeralStubbedURLSessionNotNil() {

--- a/Tests/StubbornNetworkTests/TestHelper.swift
+++ b/Tests/StubbornNetworkTests/TestHelper.swift
@@ -1,0 +1,42 @@
+//
+//  TestHelper.swift
+//  
+//
+//  Created by Martin Kim Dung-Pham on 20.11.19.
+//
+
+import Foundation
+
+struct TestHelper {
+
+    /// returns the path to the stubs to use during testing
+    static func testingStubSourcePath() -> String {
+        testingStubSourceUrl().absoluteString
+    }
+
+    /// returns the file url to the stubs to use during testing
+    static func testingStubSourceUrl() -> URL {
+        let testProcessInfo = ProcessInfo()
+        let exportedDirectoryPath = testProcessInfo.environment["TRAVIS_BUILD_DIR"] ?? testProcessInfo.environment["STUB_DIR"]
+        let stubDirectoryPath: String?
+        if let path = exportedDirectoryPath {
+            stubDirectoryPath = path
+        } else {
+            stubDirectoryPath = testProcessInfo.environment["XCTestConfigurationFilePath"]
+        }
+        assert(stubDirectoryPath != nil,
+               """
+               Incorrect Test Setup ⚠️
+               \t... Please export either a TRAVIS_BUILD_DIR or a STUB_DIR to store the stubs during test execution.
+               \t... what about giving `export STUB_DIR='./stubs' && swift test` a try?\n
+               """)
+        let url = URL(string: stubDirectoryPath!)
+        assert(url != nil,
+        """
+        Incorrect Test Setup ⚠️
+        \t... The path to the testing stubs you provided (\(stubDirectoryPath!)) is not valid.
+        """)
+
+        return url!
+    }
+}

--- a/Tests/StubbornNetworkTests/TestHelper.swift
+++ b/Tests/StubbornNetworkTests/TestHelper.swift
@@ -17,13 +17,17 @@ struct TestHelper {
     /// returns the file url to the stubs to use during testing
     static func testingStubSourceUrl() -> URL {
         let testProcessInfo = ProcessInfo()
-        let exportedDirectoryPath = testProcessInfo.environment["TRAVIS_BUILD_DIR"] ?? testProcessInfo.environment["STUB_DIR"]
+
+        let exportedDirectoryPath = testProcessInfo.environment["TRAVIS_BUILD_DIR"] ??
+            testProcessInfo.environment["STUB_DIR"]
+
         let stubDirectoryPath: String?
         if let path = exportedDirectoryPath {
             stubDirectoryPath = path
         } else {
             stubDirectoryPath = testProcessInfo.environment["XCTestConfigurationFilePath"]
         }
+
         assert(stubDirectoryPath != nil,
                """
                Incorrect Test Setup ⚠️


### PR DESCRIPTION
It is difficult to figure out how to execute **The Stubborn Network** unit tests locally. This pull request improves the situation.

When the required path to the stubs is not exported when executing tests on the command line, the following output is now shown:

```shell
[the-stubborn-network] swift test                                                                                                                                                                                 local-test-execution  ✭ ✈ ✱
[3/3] Linking StubbornNetworkPackageTests
Assertion failed: Incorrect Test Setup ⚠️
	... Please export either a TRAVIS_BUILD_DIR or a STUB_DIR to store the stubs during test execution.
	... what about giving `export STUB_DIR='./stubs' && swift test` a try?
: file /Users/kim/Development/the-stubborn-network/Tests/StubbornNetworkTests/TestHelper.swift, line 27
Exited with signal code 4
```