### PR TITLE
Add record mode to record only new requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ let networkClient = NetworkClient(urlSession: urlSession)
 There are 3 parameters passed in as environment variables to the application under test in order to specify that we want to stub network responses, what to stub, where to find/place them. Some of these will be handled more elegantly in the future:
 
 1. each test assigns its function name like `testBytesText` to create a dedicated stub source with stubs for network requests of each individual test case
-2. the _stub path_ points to the directory where the stub source with the stubs is stored for `.playback` / where stubs will be recorded to when `.recording`
+2. the _stub path_ points to the directory where the stub source with the stubs is stored for `.playback` / where stubs will be recorded to when `.record`
 3. the _TESTING_ parameter simply indicates to the application (see _App Configuration_ above) that we are in a test environment
 
 <details><summary><a href='https://github.com/q231950/the-stubborn-network-demo/blob/master/DemoUITests/DemoUITests.swift'>UI Test Configuration</a></summary>
@@ -117,7 +117,7 @@ A SwiftUI Preview utilizes **The Stubborn Network** mostly like a cache. You rec
 static var previews: some View {
     let urlSession = StubbornNetwork.makePersistentSession(withName: "ContentView_Previews", path: "\(ProcessInfo().environment["PROJECT_DIR"] ?? "")/stubs")
     /// `.playback` is the default, so after recording you can remove the following line or set it to .playback
-    urlSession.recordMode = .recording
+    urlSession.recordMode = .record
 
     let networkClient = NetworkClient(urlSession: urlSession)
     /// Use the stubbed `networkClient`...

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ if processInfo.testing == true {
     let urlSession = StubbornNetwork.makePersistentSession()
 
     /// `.playback` is the default, so after recording you can remove the following line or set it to .playback
-    urlSession.recordMode = .recording
+    urlSession.recordMode = .record
 }
 
 let networkClient = NetworkClient(urlSession: urlSession)

--- a/Sources/StubbornNetwork/EphemeralStubSource.swift
+++ b/Sources/StubbornNetwork/EphemeralStubSource.swift
@@ -31,6 +31,10 @@ extension EphemeralStubSource {
         }
     }
 
+    func hasStub(_ request: URLRequest) -> Bool {
+        expectedDatas[request] != nil
+    }
+
     func dataTask(with request: URLRequest, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTask {
         return URLSessionDataTaskStub(data: expectedDatas[request] ?? nil,
                                       response: expectedResponses[request] ?? nil,

--- a/Sources/StubbornNetwork/EphemeralStubSource.swift
+++ b/Sources/StubbornNetwork/EphemeralStubSource.swift
@@ -10,15 +10,15 @@ import Foundation
 /// This stub source only lives in memory. It is most useful for unit tests where a method
 /// is tested against a specific request.
 /// `EphemeralStubSource` is normally not used to stub a multitude of requests.
-struct EphemeralStubSource: StubSourceProtocol {
+class EphemeralStubSource: StubSourceProtocol {
+    var stubs = [RequestStub]()
     var expectedDatas = [URLRequest: Data?]()
     var expectedResponses = [URLRequest: URLResponse?]()
     var expectedErrors = [URLRequest: Error?]()
-}
 
-/// `EphemeralStubSource` conforms to `StubSourceProtocol`
-extension EphemeralStubSource {
-    mutating func store(_ stub: RequestStub) {
+    func store(_ stub: RequestStub) {
+        stubs.append(stub)
+
         if let data = stub.data {
             expectedDatas[stub.request] = data
         }
@@ -32,7 +32,7 @@ extension EphemeralStubSource {
     }
 
     func hasStub(_ request: URLRequest) -> Bool {
-        expectedDatas[request] != nil
+        stubs.contains(where: { $0.request == request })
     }
 
     func dataTask(with request: URLRequest, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTask {

--- a/Sources/StubbornNetwork/PersistentStubSource.swift
+++ b/Sources/StubbornNetwork/PersistentStubSource.swift
@@ -64,6 +64,10 @@ struct PersistentStubSource: StubSourceProtocol {
             print("\(error)")
         }
     }
+
+    func hasStub(_ request: URLRequest) -> Bool {
+        stub(forRequest: request) != nil
+    }
 }
 
 extension URLRequest {

--- a/Sources/StubbornNetwork/RecordMode.swift
+++ b/Sources/StubbornNetwork/RecordMode.swift
@@ -8,6 +8,12 @@
 import Foundation
 
 public enum RecordMode {
-    case recording
+    // freshly records all stubs
+    case record
+
+    // records only stubs which don't exist yet
+    case recordNew
+
+    // plays stubs back and does not record anything
     case playback
 }

--- a/Sources/StubbornNetwork/RequestStub.swift
+++ b/Sources/StubbornNetwork/RequestStub.swift
@@ -97,7 +97,7 @@ struct RequestStub: CustomDebugStringConvertible, Codable {
 extension RequestStub: Equatable {
     static func == (lhs: RequestStub, rhs: RequestStub) -> Bool {
         return lhs.data == rhs.data &&
-            lhs.request == rhs.request &&
+        lhs.request.matches(request: rhs.request) &&
             lhs.error?.localizedDescription == rhs.error?.localizedDescription &&
             lhs.response == rhs.response
     }

--- a/Sources/StubbornNetwork/StubSourceProtocol.swift
+++ b/Sources/StubbornNetwork/StubSourceProtocol.swift
@@ -15,6 +15,10 @@ protocol StubSourceProtocol {
     /// - Parameter stub: The stub to store
     mutating func store(_ stub: RequestStub)
 
+    /// Get information about which requests have a stored stub
+    /// - Parameter request: The request to check
+    func hasStub(_ request: URLRequest) -> Bool
+
     /// This function loads a stub for the for a given request and returns a `URLSessionTask`
     /// and will execute the closure with the previously stubbed data/response/error
     /// once the data task is resumed.

--- a/Sources/StubbornNetwork/URLSessionStub.swift
+++ b/Sources/StubbornNetwork/URLSessionStub.swift
@@ -80,7 +80,8 @@ extension URLSessionStub {
                 if stubSource.hasStub(request) {
                     // return a stubbed data task if the request has been stubbed already
                     return stubSource.dataTask(with: request, completionHandler: {(data, response, error) in
-                        let processedData = self.bodyDataProcessor?.dataForDeliveringResponseBody(data: data, of: request)
+                        let processedData = self.bodyDataProcessor?
+                            .dataForDeliveringResponseBody(data: data, of: request)
                         let preparedData = processedData ?? data
                         completionHandler(preparedData, response, error)
                     })

--- a/Sources/StubbornNetwork/URLSessionStub.swift
+++ b/Sources/StubbornNetwork/URLSessionStub.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum NetworkStubError: Error {
     case unexpectedRequest(String)
-    case missingStubSource(String)
 }
 
 class URLSessionStub: URLSession, StubbornURLSession {

--- a/Sources/StubbornNetwork/URLSessionStub.swift
+++ b/Sources/StubbornNetwork/URLSessionStub.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum NetworkStubError: Error {
     case unexpectedRequest(String)
+    case missingStubSource(String)
 }
 
 class URLSessionStub: URLSession, StubbornURLSession {
@@ -65,16 +66,33 @@ extension URLSessionStub {
     override func dataTask(with request: URLRequest,
                            completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void)
         -> URLSessionDataTask {
+            guard let stubSource = stubSource else {
+                abort()
+            }
+
             switch recordMode {
-            case .recording:
-                assert(stubSource != nil)
+            case .record:
+                // return a real data task and record the result
+                return endToEndURLSession.dataTask(with: request, completionHandler: { (data, response, error) in
+                    self.stub(request, data: data, response: response, error: error)
+                    completionHandler(data, response, error)
+                })
+            case .recordNew:
+                if stubSource.hasStub(request) {
+                    // return a stubbed data task if the request has been stubbed already
+                    return stubSource.dataTask(with: request, completionHandler: {(data, response, error) in
+                        let processedData = self.bodyDataProcessor?.dataForDeliveringResponseBody(data: data, of: request)
+                        let preparedData = processedData ?? data
+                        completionHandler(preparedData, response, error)
+                    })
+                }
+                // return a real data task and record the result if the request is not stubbed yet
                 return endToEndURLSession.dataTask(with: request, completionHandler: { (data, response, error) in
                     self.stub(request, data: data, response: response, error: error)
                     completionHandler(data, response, error)
                 })
             case .playback:
-                assert(stubSource != nil)
-                return stubSource!.dataTask(with: request, completionHandler: {(data, response, error) in
+                return stubSource.dataTask(with: request, completionHandler: {(data, response, error) in
                     let processedData = self.bodyDataProcessor?.dataForDeliveringResponseBody(data: data, of: request)
                     let preparedData = processedData ?? data
                     completionHandler(preparedData, response, error)

--- a/Tests/StubbornNetworkTests/URLSessionStubTests.swift
+++ b/Tests/StubbornNetworkTests/URLSessionStubTests.swift
@@ -15,6 +15,10 @@ class TestingStubSource: StubSourceProtocol {
         stored = stub
     }
 
+    func hasStub(_ request: URLRequest) -> Bool {
+        stored != nil
+    }
+
     func dataTask(with request: URLRequest, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTask {
         return URLSessionDataTask()
     }
@@ -64,7 +68,7 @@ class URLSessionStubTests: XCTestCase {
 
         let urlSessionStub = URLSessionStub(configuration: .ephemeral,
                                             endToEndURLSession: urlSessionStubStub)
-        urlSessionStub.recordMode = .recording
+        urlSessionStub.recordMode = .record
 
         let dataTask = urlSessionStub.dataTask(with: request) { (_, _, _) in
             exp.fulfill()

--- a/Tests/StubbornNetworkTests/URLSessionStubTests.swift
+++ b/Tests/StubbornNetworkTests/URLSessionStubTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class TestingStubSource: EphemeralStubSource {
 
-    // Keep track on what is being stored
+    // Keep track of what is being stored
     var stored = [RequestStub]()
 
     override func store(_ stub: RequestStub) {
@@ -167,6 +167,7 @@ class URLSessionStubTests: XCTestCase {
         ("testStubsRequests", testStubsRequests),
         ("testDefaultRecordMode", testDefaultRecordMode),
         ("testRecordsInRecordMode", testRecordsInRecordMode),
+        ("testRecordsOnlyNewInRecordNewMode", testRecordsOnlyNewInRecordNewMode),
         ("testStoresProcessedRequestBody", testStoresProcessedRequestBody),
         ("testStoresProcessedResponseBody", testStoresProcessedResponseBody),
     ]

--- a/Tests/StubbornNetworkTests/URLSessionStubTests.swift
+++ b/Tests/StubbornNetworkTests/URLSessionStubTests.swift
@@ -8,25 +8,37 @@
 import XCTest
 @testable import StubbornNetwork
 
-class TestingStubSource: StubSourceProtocol {
-    var stored: RequestStub?
+class TestingStubSource: EphemeralStubSource {
 
-    func store(_ stub: RequestStub) {
-        stored = stub
+    // Keep track on what is being stored
+    var stored = [RequestStub]()
+
+    override func store(_ stub: RequestStub) {
+        stored.append(stub)
+        super.store(stub)
     }
 
-    func hasStub(_ request: URLRequest) -> Bool {
-        stored != nil
+    // Manipulate storage of the StubSource
+    func injectStubIntoStorage(stub: RequestStub) {
+        super.store(stub)
     }
 
-    func dataTask(with request: URLRequest, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTask {
-        return URLSessionDataTask()
-    }
 }
 
 class URLSessionStubTests: XCTestCase {
 
-    var request = URLRequest(url: URL(string: "127.0.0.1")!)
+    var requestA: URLRequest = {
+        var request = URLRequest(url: URL(string: "127.0.0.1")!)
+        request.httpBody = nil
+        return request
+    }()
+
+    var requestB: URLRequest = {
+        var request = URLRequest(url: URL(string: "127.0.0.2")!)
+        request.httpBody = nil
+        return request
+    }()
+
     let urlSessionStub = URLSessionStub(configuration: .ephemeral)
 
     func testStubsRequests() {
@@ -34,15 +46,15 @@ class URLSessionStubTests: XCTestCase {
         let expectedData = "abc".data(using: .utf8)
         let expectedResponse = HTTPURLResponse()
 
-        request.httpMethod = "POST"
-        request.allHTTPHeaderFields = ["B": "BBB"]
+        requestA.httpMethod = "POST"
+        requestA.allHTTPHeaderFields = ["B": "BBB"]
 
-        urlSessionStub.stub(request,
+        urlSessionStub.stub(requestA,
                             data: "abc".data(using: .utf8),
                             response: expectedResponse,
                             error: TestError.expected)
 
-        let dataTask = urlSessionStub.stubSource?.dataTask(with: request) { (data, response, error) in
+        let dataTask = urlSessionStub.stubSource?.dataTask(with: requestA) { (data, response, error) in
             XCTAssertEqual(expectedData, data)
             XCTAssertEqual(expectedResponse, response)
             XCTAssertEqual(TestError.expected.localizedDescription, error?.localizedDescription)
@@ -61,16 +73,16 @@ class URLSessionStubTests: XCTestCase {
     func testRecordsInRecordMode() {
         let exp = expectation(description: "Wait for data task completion")
         let urlSessionStubStub = URLSessionStub(configuration: .ephemeral)
-        request.httpMethod = "POST"
-        request.allHTTPHeaderFields = ["B": "BBB"]
+        requestA.httpMethod = "POST"
+        requestA.allHTTPHeaderFields = ["B": "BBB"]
 
-        urlSessionStubStub.stub(request, data: "abc".data(using: .utf8))
+        urlSessionStubStub.stub(requestA, data: "abc".data(using: .utf8))
 
         let urlSessionStub = URLSessionStub(configuration: .ephemeral,
                                             endToEndURLSession: urlSessionStubStub)
         urlSessionStub.recordMode = .record
 
-        let dataTask = urlSessionStub.dataTask(with: request) { (_, _, _) in
+        let dataTask = urlSessionStub.dataTask(with: requestA) { (_, _, _) in
             exp.fulfill()
         }
         dataTask.resume()
@@ -78,7 +90,7 @@ class URLSessionStubTests: XCTestCase {
         wait(for: [exp], timeout: 0.001)
 
         let stubDidStoreExpectation = expectation(description: "StubSource finds a record for the request")
-        let stubSourceDataTask = urlSessionStub.stubSource?.dataTask(with: request) { (data, response, error) in
+        let stubSourceDataTask = urlSessionStub.stubSource?.dataTask(with: requestA) { (data, response, error) in
             XCTAssertEqual(data, "abc".data(using: .utf8))
             XCTAssertNil(response)
             XCTAssertNil(error)
@@ -89,30 +101,59 @@ class URLSessionStubTests: XCTestCase {
         wait(for: [stubDidStoreExpectation], timeout: 0.001)
     }
 
+    func testRecordsOnlyNewInRecordNewMode() {
+        let asyncExpectation = expectation(description: "Wait for data task completion")
+        asyncExpectation.expectedFulfillmentCount = 2
+
+        let stubSource = TestingStubSource()
+        let urlSessionStubStub = URLSessionStub(configuration: .ephemeral)
+        let urlSessionStub = URLSessionStub(stubSource: stubSource, endToEndURLSession: urlSessionStubStub)
+
+        // when the stub source has stubbed request A
+        stubSource.injectStubIntoStorage(stub: RequestStub(request: requestA))
+
+        // and the record mode tells to only record new requests
+        urlSessionStub.recordMode = .recordNew
+
+        // when resuming the data task of the existing, stubbed request A
+        urlSessionStub.dataTask(with: requestA) { (_, _, _) in
+            asyncExpectation.fulfill()
+        }.resume()
+
+        // and a never recorded request B
+        urlSessionStub.dataTask(with: requestB) { (data, response, error) in
+            asyncExpectation.fulfill()
+        }.resume()
+        wait(for: [asyncExpectation], timeout: 0.001)
+
+        // then only the new request B should have been stored freshly
+        XCTAssertEqual(stubSource.stored.filter({ $0.request.matches(request: requestB) }).count, 1)
+    }
+
     func testStoresProcessedRequestBody() {
         let stubSource = TestingStubSource()
         let urlSessionStub = URLSessionStub(stubSource: stubSource)
         urlSessionStub.bodyDataProcessor = TestingBodyDataProcessor()
 
-        request.httpBody = "11x11".data(using: .utf8)
-        urlSessionStub.stub(request,
+        requestA.httpBody = "11x11".data(using: .utf8)
+        urlSessionStub.stub(requestA,
                             data: nil,
                             response: nil,
                             error: nil)
 
-        XCTAssertEqual(stubSource.stored?.request.httpBody, "1111".data(using: .utf8))
+        XCTAssertEqual(stubSource.stored.first?.request.httpBody, "1111".data(using: .utf8))
     }
 
     func testStoresProcessedResponseBody() {
         let exp = expectation(description: "Wait for data task completion")
         urlSessionStub.bodyDataProcessor = TestingBodyDataProcessor()
 
-        urlSessionStub.stub(request,
+        urlSessionStub.stub(requestA,
                             data: "11y11".data(using: .utf8),
                             response: nil,
                             error: nil)
 
-        let dataTask = urlSessionStub.stubSource?.dataTask(with: request) { (data, _, _) in
+        let dataTask = urlSessionStub.stubSource?.dataTask(with: requestA) { (data, _, _) in
             XCTAssertEqual("1111".data(using: .utf8), data)
 
             exp.fulfill()

--- a/Tests/StubbornNetworkTests/URLSessionStubTests.swift
+++ b/Tests/StubbornNetworkTests/URLSessionStubTests.swift
@@ -121,7 +121,7 @@ class URLSessionStubTests: XCTestCase {
         }.resume()
 
         // and a never recorded request B
-        urlSessionStub.dataTask(with: requestB) { (data, response, error) in
+        urlSessionStub.dataTask(with: requestB) { (_, _, _) in
             asyncExpectation.fulfill()
         }.resume()
         wait(for: [asyncExpectation], timeout: 0.001)


### PR DESCRIPTION
Resolves #34 

In addition to 🔝this pull request contains some additional changes:
- renames `.recording` to `.record`
- makes request stub comparison stricter by taking _request_ into account