### PR TITLE
Update api

### DIFF
--- a/Sources/StubbornNetwork/Extensions/URLRequest+Matcher.swift
+++ b/Sources/StubbornNetwork/Extensions/URLRequest+Matcher.swift
@@ -36,7 +36,7 @@ extension URLRequest {
         }
 
         if options.contains(.body) {
-            if (httpBody != otherRequest.httpBody && httpBody != nil && otherRequest.httpBody != nil) {
+            if httpBody != otherRequest.httpBody && httpBody != nil && otherRequest.httpBody != nil {
                 return false
             }
         }

--- a/Sources/StubbornNetwork/Extensions/URLRequest+Matcher.swift
+++ b/Sources/StubbornNetwork/Extensions/URLRequest+Matcher.swift
@@ -10,18 +10,37 @@ import Foundation
 extension URLRequest {
 
     /// Verifies if this request and matches the other one.
-    func matches(otherRequest: URLRequest) -> Bool {
-        let sortedA = allHTTPHeaderFields?.map({ (key, value) -> String in
-            return key.lowercased() + value
-        }).sorted(by: <)
+    func matches(otherRequest: URLRequest, options: RequestMatcherOptions? = .lenient) -> Bool {
+        guard let options = options else { return false }
 
-        let sortedB = otherRequest.allHTTPHeaderFields?.map({ (key, value) -> String in
-            return key.lowercased() + value
-        }).sorted(by: <)
+        if options.contains(.url) && url != otherRequest.url {
+            return false
+        }
 
-        return url == otherRequest.url &&
-            httpMethod == otherRequest.httpMethod &&
-            (httpBody == otherRequest.httpBody || httpBody == nil && otherRequest.httpBody == nil) &&
-            sortedA == sortedB
+        if options.contains(.headers) {
+            let sortedA = allHTTPHeaderFields?.map({ (key, value) -> String in
+                return key.lowercased() + value
+            }).sorted(by: <)
+
+            let sortedB = otherRequest.allHTTPHeaderFields?.map({ (key, value) -> String in
+                return key.lowercased() + value
+            }).sorted(by: <)
+
+            if sortedA != sortedB {
+                return false
+            }
+        }
+
+        if options.contains(.httpMethod) && httpMethod != otherRequest.httpMethod {
+            return false
+        }
+
+        if options.contains(.body) {
+            if (httpBody != otherRequest.httpBody && httpBody != nil && otherRequest.httpBody != nil) {
+                return false
+            }
+        }
+
+        return true
     }
 }

--- a/Sources/StubbornNetwork/Stub Recorder/StubRecorder.swift
+++ b/Sources/StubbornNetwork/Stub Recorder/StubRecorder.swift
@@ -18,6 +18,7 @@ struct StubRecorder: StubRecording {
 
     func record(_ task: URLSessionTask?,
                 processor: BodyDataProcessor?,
+                options: RequestMatcherOptions?,
                 completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
 
         guard let task = task, let request = task.originalRequest else { return }
@@ -39,7 +40,7 @@ struct StubRecorder: StubRecording {
                                        response: response,
                                        error: error)
 
-                self.stubSource.store(stub)
+                self.stubSource.store(stub, options: options)
 
                 completion(data, response, error)
             }.resume()

--- a/Sources/StubbornNetwork/Stub Recorder/StubRecorderProtocol.swift
+++ b/Sources/StubbornNetwork/Stub Recorder/StubRecorderProtocol.swift
@@ -12,13 +12,19 @@ protocol StubRecording {
     /// Record the response of a task into a stub.
     ///
     /// - Parameters:
-    ///   - task: the task to record a stub for
+    ///   - task: the task to record a stub for.
     ///   - processor: When this optional processor is given, the stubbed data will be passed to it prior to storing it.
     ///                        This allows to alter the request and response data of the stub. It is useful when sensitive
     ///                        information should not end up in the stubs.
-    ///   - completion: the completion is called with the unaltered response from performing the task's request on a `URLSession`
+    ///   - options: The options how client requests and stubs should be matched. If only the url of a request is
+    ///              sufficient to determine the correct stubbed request, then `.url` might be passed and one would not
+    ///              need to bother making the stubbed request's header and body exactly fit to the expected client
+    ///              request.
+    ///   - completion: the completion is called with the unaltered response from performing the task's
+    ///                 request on a `URLSession`.
     func record(_ task: URLSessionTask?,
                 processor: BodyDataProcessor?,
+                options: RequestMatcherOptions?,
                 completion: @escaping (Data?, URLResponse?, Error?) -> Void)
 
 }

--- a/Sources/StubbornNetwork/Stub Sources/CombinedStubSource.swift
+++ b/Sources/StubbornNetwork/Stub Sources/CombinedStubSource.swift
@@ -14,18 +14,18 @@ import Foundation
 struct CombinedStubSource: StubSourceProtocol {
     let sources: [StubSourceProtocol]
 
-    func store(_ stub: RequestStub) {
-        sources.forEach { $0.store(stub) }
+    func store(_ stub: RequestStub, options: RequestMatcherOptions?) {
+        sources.forEach { $0.store(stub, options: options) }
     }
 
-    func hasStub(_ request: URLRequest) -> Bool {
-        sources.contains { $0.hasStub(request) }
+    func hasStub(_ request: URLRequest, options: RequestMatcherOptions?) -> Bool {
+        sources.contains { $0.hasStub(request, options: options) }
     }
 
-    func stub(forRequest request: URLRequest) -> RequestStub? {
+    func stub(forRequest request: URLRequest, options: RequestMatcherOptions?) -> RequestStub? {
         sources.first { (source) -> Bool in
-            source.hasStub(request)
-        }?.stub(forRequest: request)
+            source.hasStub(request, options: options)
+        }?.stub(forRequest: request, options: options)
     }
 
     func clear() {

--- a/Sources/StubbornNetwork/Stub Sources/EphemeralStubSource.swift
+++ b/Sources/StubbornNetwork/Stub Sources/EphemeralStubSource.swift
@@ -14,19 +14,19 @@ class EphemeralStubSource: StubSourceProtocol {
 
     var stubs = [RequestStub]()
 
-    func store(_ stub: RequestStub) {
-        if !hasStub(stub.request) {
+    func store(_ stub: RequestStub, options: RequestMatcherOptions?) {
+        if !hasStub(stub.request, options: options) {
             stubs.append(stub)
         }
     }
 
-    func hasStub(_ request: URLRequest) -> Bool {
-        stubs.contains(where: { $0.request.matches(otherRequest: request) })
+    func hasStub(_ request: URLRequest, options: RequestMatcherOptions?) -> Bool {
+        stubs.contains(where: { $0.request.matches(otherRequest: request, options: options) })
     }
 
-    func stub(forRequest request: URLRequest) -> RequestStub? {
+    func stub(forRequest request: URLRequest, options: RequestMatcherOptions?) -> RequestStub? {
         stubs.first { (stub) -> Bool in
-            stub.request.matches(otherRequest: request)
+            stub.request.matches(otherRequest: request, options: options)
         }
     }
 

--- a/Sources/StubbornNetwork/Stub Sources/PersistentStubSource.swift
+++ b/Sources/StubbornNetwork/Stub Sources/PersistentStubSource.swift
@@ -43,13 +43,13 @@ class PersistentStubSource: StubSourceProtocol {
         return try Data(contentsOf: url)
     }
 
-    func stub(forRequest request: URLRequest) -> RequestStub? {
+    func stub(forRequest request: URLRequest, options: RequestMatcherOptions?) -> RequestStub? {
         print("Loading stub for request \(request.url?.absoluteString ?? "unknown")")
-        return stubs.first(where: { request.matches(otherRequest: $0.request) })
+        return stubs.first(where: { request.matches(otherRequest: $0.request, options: options) })
     }
 
-    func store(_ stub: RequestStub) {
-        if hasStub(stub.request) {
+    func store(_ stub: RequestStub, options: RequestMatcherOptions?) {
+        if hasStub(stub.request, options: options) {
             print("Not storing stub because its request has already been stubbed.")
         } else {
             print("Storing stub: \(stub) at \(path.absoluteString).")
@@ -79,8 +79,8 @@ class PersistentStubSource: StubSourceProtocol {
         }
     }
 
-    func hasStub(_ request: URLRequest) -> Bool {
-        stub(forRequest: request) != nil
+    func hasStub(_ request: URLRequest, options: RequestMatcherOptions?) -> Bool {
+        stub(forRequest: request, options: options) != nil
     }
 }
 

--- a/Sources/StubbornNetwork/Stub Sources/StubSourceProtocol.swift
+++ b/Sources/StubbornNetwork/Stub Sources/StubSourceProtocol.swift
@@ -15,15 +15,15 @@ protocol StubSourceProtocol {
 
     /// Store a stub into the _Stub Source_.
     /// - Parameter stub: The stub to store
-    func store(_ stub: RequestStub)
+    func store(_ stub: RequestStub, options: RequestMatcherOptions?)
 
     /// Get information about which requests have a stored stub
     /// - Parameter request: The request to check the availability of a stub for
-    func hasStub(_ request: URLRequest) -> Bool
+    func hasStub(_ request: URLRequest, options: RequestMatcherOptions?) -> Bool
 
     /// Get a `RequestStub` if one has been previously recorded for the given request
     /// - Parameter request: the request to find and return a stub for
-    func stub(forRequest request: URLRequest) -> RequestStub?
+    func stub(forRequest request: URLRequest, options: RequestMatcherOptions?) -> RequestStub?
 
     /// Clear the _Stub Source_. This ideally removes all stubs from the _Stub Source_.
     func clear()

--- a/Sources/StubbornNetwork/StubbedSessionURLProtocol.swift
+++ b/Sources/StubbornNetwork/StubbedSessionURLProtocol.swift
@@ -45,7 +45,8 @@ public class StubbedSessionURLProtocol: URLProtocol {
 
         if let request = task?.originalRequest {
 
-            if let stub = stubbornNetwork.stubSource.stub(forRequest: request) {
+            if let stub = stubbornNetwork.stubSource.stub(forRequest: request,
+                                                          options: stubbornNetwork.requestMatcherOptions) {
                 playback(stub) { notifyFinished() }
             } else {
                 record(task) { data, response, error in
@@ -110,7 +111,9 @@ extension StubbedSessionURLProtocol {
     }
 
     fileprivate func record(_ task: URLSessionTask?, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
-        recorder.record(task, processor: stubbornNetwork.bodyDataProcessor, completion: completion)
+        recorder.record(task, processor: stubbornNetwork.bodyDataProcessor,
+                        options: stubbornNetwork.requestMatcherOptions,
+                        completion: completion)
     }
 
     /// Gets the information about whether or not a URL scheme is supported by this protocol.

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -58,7 +58,6 @@ public class StubbornNetwork {
     ///  - modify the response body just before delivering a stub
     public var bodyDataProcessor: BodyDataProcessor?
 
-
     /// Stubs a given request.
     ///
     /// When the client makes a request similar to the given `request`, data and response or error will be played back.

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -30,7 +30,7 @@ public class StubbornNetwork {
 
     private let processInfo: ProcessInfo
 
-    /// The standard Stubborn Network used be all clients
+    /// The nil resettable standard Stubborn Network
     public static var standard: StubbornNetwork! {
         get {
             if _standard == nil {
@@ -57,6 +57,28 @@ public class StubbornNetwork {
     ///  - modify the response body before storing a stub
     ///  - modify the response body just before delivering a stub
     public var bodyDataProcessor: BodyDataProcessor?
+
+
+    /// Stubs a given request.
+    ///
+    /// When the client makes a request similar to the given `request`, data and response or error will be played back.
+    ///
+    /// - Parameters:
+    ///   - request: the request to be stubbed
+    ///   - data: this data will be played back.
+    ///   - response: this response will be played back.
+    ///   - error: this error will be played back. If an error is given it inhibits any data and response from
+    ///            being replayed.
+    public func stub(request: URLRequest,
+                     data: Data? = nil,
+                     response: URLResponse? = nil,
+                     error: Error? = nil) {
+        let stub = RequestStub(request: request,
+                               data: data,
+                               response: response,
+                               error: error)
+        stubSource.store(stub, options: requestMatcherOptions)
+    }
 
     /// Removes the body data processor
     func removeBodyDataProcessor() {

--- a/Sources/StubbornNetwork/StubbornNetwork.swift
+++ b/Sources/StubbornNetwork/StubbornNetwork.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+public struct RequestMatcherOptions: OptionSet {
+ public let rawValue: Int
+
+ public init(rawValue: Int) {
+    self.rawValue = rawValue
+}
+
+ public static let url = RequestMatcherOptions(rawValue: 1 << 0)
+ public static let httpMethod = RequestMatcherOptions(rawValue: 1 << 1)
+ public static let headers = RequestMatcherOptions(rawValue: 1 << 2)
+ public static let body = RequestMatcherOptions(rawValue: 1 << 3)
+
+ public static let lenient: RequestMatcherOptions = [.url]
+ public static let strict: RequestMatcherOptions = [.url, .httpMethod, .headers, .body]
+}
+
 ///
 /// The Stubborn Network - a Swifty and Clean Stubbing Machine.
 ///
@@ -15,7 +31,26 @@ public class StubbornNetwork {
     private let processInfo: ProcessInfo
 
     /// The standard Stubborn Network used be all clients
-    public static let standard = StubbornNetwork()
+    public static var standard: StubbornNetwork! {
+        get {
+            if _standard == nil {
+                _standard = StubbornNetwork()
+            }
+
+            return _standard
+        }
+        set {
+            _standard = newValue
+        }
+    }
+    private static var _standard: StubbornNetwork?
+
+    /// The matcher options for requests.
+    ///
+    /// More options will result in the requirement of the stubbed requests being very much like
+    /// the actual requests. The `.lenient` option set for example only checks for the URL of a
+    /// stub to decide if it should playback that stub or check the next one.
+    public var requestMatcherOptions: RequestMatcherOptions = .strict
 
     /// The bodyDataProcessor allows modification of stubbed body data.
     ///  - modify the request body before storing a stub
@@ -36,8 +71,8 @@ public class StubbornNetwork {
 
     var ephemeralStubSource: StubSourceProtocol?
 
-    convenience init() {
-        self.init(processInfo: ProcessInfo(), nil)
+    public convenience init() {
+        self.init(processInfo: ProcessInfo())
     }
 
     init(processInfo: ProcessInfo? = ProcessInfo(),

--- a/Tests/StubbornNetworkTests/BodyDataProcessorTests.swift
+++ b/Tests/StubbornNetworkTests/BodyDataProcessorTests.swift
@@ -37,7 +37,7 @@ class BodyDataProcessorTests: XCTestCase {
         let requestStub = RequestStub(request: request, data: data, response: nil, error: nil)
 
         // when
-        StubbornNetwork.standard.ephemeralStubSource?.store(requestStub)
+        StubbornNetwork.standard.ephemeralStubSource?.store(requestStub, options: .strict)
 
         // then
         session.dataTask(with: try XCTUnwrap(URL(string: "127.0.0.1"))) { (data, _, _) in
@@ -56,7 +56,7 @@ class BodyDataProcessorTests: XCTestCase {
         let requestStub = RequestStub(request: request, data: data, response: nil, error: nil)
 
         // when
-        StubbornNetwork.standard.ephemeralStubSource?.store(requestStub)
+        StubbornNetwork.standard.ephemeralStubSource?.store(requestStub, options: .strict)
 
         // then
         session.dataTask(with: try XCTUnwrap(URL(string: "127.0.0.1"))) { (data, _, _) in
@@ -72,7 +72,7 @@ class BodyDataProcessorTests: XCTestCase {
         let exp = expectation(description: "Wait for session")
         let data = "123".data(using: .utf8)
         let requestStub = RequestStub(request: request, data: data, response: nil, error: nil)
-        StubbornNetwork.standard.ephemeralStubSource?.store(requestStub)
+        StubbornNetwork.standard.ephemeralStubSource?.store(requestStub, options: .strict)
 
         // when
         session.dataTask(with: request) { (data, _, _) in

--- a/Tests/StubbornNetworkTests/CombinedStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/CombinedStubSourceTests.swift
@@ -20,10 +20,10 @@ class CombinedStubSourceTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "http://elbedev.com"))
         let request = URLRequest(url: url)
         let requestStub = RequestStub(request: request)
-        combinedStubSource.store(requestStub)
+        combinedStubSource.store(requestStub, options: .strict)
 
-        XCTAssertTrue(source1.hasStub(request))
-        XCTAssertTrue(source2.hasStub(request))
+        XCTAssertTrue(source1.hasStub(request, options: .strict))
+        XCTAssertTrue(source2.hasStub(request, options: .strict))
     }
 
     func test_CombinedStubSource_returnsIfAnyOfItsSourcesHasAStub() throws {
@@ -36,9 +36,9 @@ class CombinedStubSourceTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "http://elbedev.com"))
         let request = URLRequest(url: url)
         let requestStub = RequestStub(request: request)
-        source2.store(requestStub)
+        source2.store(requestStub, options: .strict)
 
-        XCTAssertTrue(combinedStubSource.hasStub(request))
+        XCTAssertTrue(combinedStubSource.hasStub(request, options: .strict))
     }
 
     func test_CombinedStubSource_clearsAllOfItsSources() throws {
@@ -51,13 +51,13 @@ class CombinedStubSourceTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "http://elbedev.com"))
         let request = URLRequest(url: url)
         let requestStub = RequestStub(request: request)
-        source1.store(requestStub)
-        source2.store(requestStub)
+        source1.store(requestStub, options: .strict)
+        source2.store(requestStub, options: .strict)
 
         combinedStubSource.clear()
 
-        XCTAssertFalse(source1.hasStub(request))
-        XCTAssertFalse(source2.hasStub(request))
+        XCTAssertFalse(source1.hasStub(request, options: .strict))
+        XCTAssertFalse(source2.hasStub(request, options: .strict))
     }
 
     static var allTests = [

--- a/Tests/StubbornNetworkTests/EphemeralStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/EphemeralStubSourceTests.swift
@@ -24,9 +24,9 @@ class EphemeralStubSourceTests: XCTestCase {
                                error: nil)
 
         let stubSource = EphemeralStubSource()
-        stubSource.store(stub)
+        stubSource.store(stub, options: .strict)
 
-        XCTAssertTrue(stubSource.hasStub(request))
+        XCTAssertTrue(stubSource.hasStub(request, options: .strict))
         XCTAssertEqual(stubSource.stubs.count, 1)
     }
 
@@ -44,8 +44,8 @@ class EphemeralStubSourceTests: XCTestCase {
                                error: nil)
 
         let stubSource = EphemeralStubSource()
-        stubSource.store(stub)
-        stubSource.store(stub)
+        stubSource.store(stub, options: .strict)
+        stubSource.store(stub, options: .strict)
 
         XCTAssertEqual(stubSource.stubs.count, 1)
     }

--- a/Tests/StubbornNetworkTests/PersistentStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/PersistentStubSourceTests.swift
@@ -43,7 +43,7 @@ class StubSourceTests: XCTestCase {
         request.httpBody = "abc".data(using: .utf8)
         request.httpMethod = "POST"
         request.allHTTPHeaderFields = ["B": "BBB"]
-        let loadedStub = stubSource.stub(forRequest: request)
+        let loadedStub = stubSource.stub(forRequest: request, options: .strict)
 
         XCTAssertNotNil(loadedStub)
     }
@@ -56,7 +56,7 @@ class StubSourceTests: XCTestCase {
         var request = URLRequest(url: url!)
         request.httpMethod = "POST"
         request.allHTTPHeaderFields = ["D": "DDD"]
-        let loadedStub = stubSource.stub(forRequest: request)
+        let loadedStub = stubSource.stub(forRequest: request, options: .strict)
 
         XCTAssertNotNil(loadedStub)
     }
@@ -71,9 +71,9 @@ class StubSourceTests: XCTestCase {
         request.allHTTPHeaderFields = ["B": "BBB"]
 
         let stub = RequestStub(request: request, data: nil, response: nil, error: nil)
-        stubSource.store(stub)
+        stubSource.store(stub, options: .strict)
 
-        let loadedStub = stubSource.stub(forRequest: request)
+        let loadedStub = stubSource.stub(forRequest: request, options: .strict)
 
         XCTAssertEqual(stub, loadedStub)
     }
@@ -88,8 +88,8 @@ class StubSourceTests: XCTestCase {
         request.allHTTPHeaderFields = ["B": "BBB"]
 
         let stub = RequestStub(request: request, data: nil, response: nil, error: nil)
-        stubSource.store(stub)
-        stubSource.store(stub)
+        stubSource.store(stub, options: .strict)
+        stubSource.store(stub, options: .strict)
 
         XCTAssertEqual(stubSource.stubs.count, 1)
     }

--- a/Tests/StubbornNetworkTests/StubRecorderTests.swift
+++ b/Tests/StubbornNetworkTests/StubRecorderTests.swift
@@ -34,7 +34,7 @@ class StubRecorderTests: XCTestCase {
         let recorder = StubRecorder(stubSource: stubSource, urlSession: urlSession)
         let task = URLSessionDataTaskStub(originalRequest: URLRequest(url: url))
 
-        recorder.record(task, processor: nil) { (data, response, _) in
+        recorder.record(task, processor: nil, options: .strict) { (data, response, _) in
             XCTAssertEqual(data, self.expectedData)
             XCTAssertEqual(response, self.expectedResponse)
         }
@@ -49,7 +49,7 @@ class StubRecorderTests: XCTestCase {
         let recorder = StubRecorder(stubSource: stubSource, urlSession: urlSession)
         let task = URLSessionDataTaskStub(originalRequest: URLRequest(url: url))
 
-        recorder.record(task, processor: nil) { (_, _, error) in
+        recorder.record(task, processor: nil, options: .strict) { (_, _, error) in
             XCTAssertEqual(error?.localizedDescription, TestError.expected.localizedDescription)
         }
     }
@@ -65,7 +65,7 @@ class StubRecorderTests: XCTestCase {
         let recorder = StubRecorder(stubSource: stubSource, urlSession: urlSession)
         let task = URLSessionDataTaskStub(originalRequest: URLRequest(url: url))
 
-        recorder.record(task, processor: nil) { (_, _, _) in }
+        recorder.record(task, processor: nil, options: .strict) { (_, _, _) in }
 
         XCTAssertEqual(self.stubSource.stubs.first?.data, self.expectedData)
         XCTAssertEqual(self.stubSource.stubs.first?.response, self.expectedResponse)
@@ -80,7 +80,7 @@ class StubRecorderTests: XCTestCase {
         let recorder = StubRecorder(stubSource: stubSource, urlSession: urlSession)
         let task = URLSessionDataTaskStub(originalRequest: URLRequest(url: url))
 
-        recorder.record(task, processor: nil) { (_, _, _) in }
+        recorder.record(task, processor: nil, options: .strict) { (_, _, _) in }
 
         let stub = try XCTUnwrap(self.stubSource.stubs.first)
         XCTAssertEqual(stub.error?.localizedDescription, TestError.expected.localizedDescription)
@@ -98,7 +98,7 @@ class StubRecorderTests: XCTestCase {
         let task = URLSessionDataTaskStub(originalRequest: URLRequest(url: url))
 
         let bodyDataProcessorStub = BodyDataProcessorStub()
-        recorder.record(task, processor: bodyDataProcessorStub) { (_, _, _) in }
+        recorder.record(task, processor: bodyDataProcessorStub, options: .strict) { (_, _, _) in }
 
         let stub = try XCTUnwrap(self.stubSource.stubs.first)
         XCTAssertEqual(String(data: try XCTUnwrap(stub.data), encoding: .utf8), "🐠🐠🐠 dataForStoringResponseBody 🐠🐠🐠")

--- a/Tests/StubbornNetworkTests/StubbedSessionURLProtocolTests.swift
+++ b/Tests/StubbornNetworkTests/StubbedSessionURLProtocolTests.swift
@@ -60,7 +60,7 @@ class StubbedSessionURLProtocolTests: XCTestCase {
         let stub = RequestStub(request: task.originalRequest!, data: expectedData, response: expectedResponse, error: nil)
 
         objectUnderTest.internalStubbornNetwork = StubbornNetwork(processInfo: ProcessInfo(), ephemeralStubSource)
-        ephemeralStubSource.store(stub)
+        ephemeralStubSource.store(stub, options: .strict)
         objectUnderTest.startLoading()
 
         XCTAssertEqual(client.didLoadData, expectedData)
@@ -81,7 +81,7 @@ class StubbedSessionURLProtocolTests: XCTestCase {
                                error: TestError.expected)
 
         objectUnderTest.internalStubbornNetwork = StubbornNetwork(processInfo: ProcessInfo(), ephemeralStubSource)
-        ephemeralStubSource.store(stub)
+        ephemeralStubSource.store(stub, options: .strict)
         objectUnderTest.startLoading()
 
         XCTAssertEqual(client.didFailWithError?.localizedDescription,
@@ -98,7 +98,7 @@ class StubbedSessionURLProtocolTests: XCTestCase {
         let stub = RequestStub(request: task.originalRequest!)
 
         objectUnderTest.internalStubbornNetwork = StubbornNetwork(processInfo: ProcessInfo(), ephemeralStubSource)
-        ephemeralStubSource.store(stub)
+        ephemeralStubSource.store(stub, options: .strict)
         objectUnderTest.startLoading()
 
         XCTAssertEqual(client.didFinishLoadingCount, 1)
@@ -115,7 +115,7 @@ class StubbedSessionURLProtocolTests: XCTestCase {
         let stub = RequestStub(request: task.originalRequest!)
 
         objectUnderTest.internalStubbornNetwork = StubbornNetwork(processInfo: ProcessInfo(), ephemeralStubSource)
-        ephemeralStubSource.store(stub)
+        ephemeralStubSource.store(stub, options: .strict)
         objectUnderTest.startLoading()
 
         XCTAssertEqual(recorder.recordCount, 0)
@@ -197,7 +197,10 @@ class URLProtocolClientStub: NSObject, URLProtocolClient {
 class StubRecorderMock: StubRecording {
     var recordCount = 0
 
-    func record(_ task: URLSessionTask?, processor: BodyDataProcessor?, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+    func record(_ task: URLSessionTask?,
+                processor: BodyDataProcessor?,
+                options: RequestMatcherOptions?,
+                completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
         recordCount += 1
         completion("⚡️".data(using: .utf8), URLResponse(), nil)
     }

--- a/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
+++ b/Tests/StubbornNetworkTests/StubbornNetworkTests.swift
@@ -67,7 +67,7 @@ final class StubbornNetworkTests: XCTestCase {
                                data: "abc".data(using: .utf8),
                                response: expectedResponse,
                                error: nil)
-        stubSource.store(stub)
+        stubSource.store(stub, options: .strict)
 
         StubbornNetwork.standard.ephemeralStubSource = stubSource
 
@@ -98,7 +98,7 @@ final class StubbornNetworkTests: XCTestCase {
                                data: "abc".data(using: .utf8),
                                response: expectedResponse,
                                error: nil)
-        stubSource.store(stub)
+        stubSource.store(stub, options: .strict)
 
         StubbornNetwork.standard.ephemeralStubSource = stubSource
 

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -16,7 +16,7 @@ class URLRequestMatcherTests: XCTestCase {
         var requestWithLowercaseHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithLowercaseHeader.setValue("alphabet", forHTTPHeaderField: "abc")
 
-        XCTAssertTrue(requestWithCapitalHeader.matches(otherRequest: requestWithLowercaseHeader))
+        XCTAssertTrue(requestWithCapitalHeader.matches(otherRequest: requestWithLowercaseHeader, options: .strict))
     }
 
     func testHeaderDuplicateMismatches() {
@@ -27,7 +27,7 @@ class URLRequestMatcherTests: XCTestCase {
         var requestWithSingleHeader = URLRequest(url: URL(string: "127.0.0.1")!)
         requestWithSingleHeader.setValue("alphabet", forHTTPHeaderField: "abc")
 
-        XCTAssertFalse(requestWithDuplicatedHeader.matches(otherRequest: requestWithSingleHeader))
+        XCTAssertFalse(requestWithDuplicatedHeader.matches(otherRequest: requestWithSingleHeader, options: .strict))
     }
 
     func testHeaderDuplicateMatches() {
@@ -39,7 +39,7 @@ class URLRequestMatcherTests: XCTestCase {
         requestWithDuplicatedLowercaseHeader.addValue("alphabet", forHTTPHeaderField: "abc")
         requestWithDuplicatedLowercaseHeader.addValue("алфавит", forHTTPHeaderField: "abc")
 
-        XCTAssertTrue(requestWithDuplicatedHeader.matches(otherRequest: requestWithDuplicatedLowercaseHeader))
+        XCTAssertTrue(requestWithDuplicatedHeader.matches(otherRequest: requestWithDuplicatedLowercaseHeader, options: .strict))
     }
 
     func testHeaderOrderMismatches() {
@@ -51,6 +51,6 @@ class URLRequestMatcherTests: XCTestCase {
         requestWithDuplicatedHeaderOtherOrder.addValue("алфавит", forHTTPHeaderField: "abc")
         requestWithDuplicatedHeaderOtherOrder.addValue("alphabet", forHTTPHeaderField: "abc")
 
-        XCTAssertFalse(requestWithDuplicatedHeader.matches(otherRequest: requestWithDuplicatedHeaderOtherOrder))
+        XCTAssertFalse(requestWithDuplicatedHeader.matches(otherRequest: requestWithDuplicatedHeaderOtherOrder, options: .strict))
     }
 }


### PR DESCRIPTION
## A New Method

A new method allows to stub directly on instances of `StubbornNetwork`:

```Swift
    /// Stubs a given request.
    ///
    /// When the client makes a request similar to the given `request`, data and response or error will be played back.
    ///
    /// - Parameters:
    ///   - request: the request to be stubbed
    ///   - data: this data will be played back.
    ///   - response: this response will be played back.
    ///   - error: this error will be played back. If an error is given it inhibits any data and response from
    ///            being replayed.
    public func stub(request: URLRequest,
                     data: Data? = nil,
                     response: URLResponse? = nil,
                     error: Error? = nil)
```

## RequestMatcherOptions

`RequestMatcherOptions` are a way to control the matching behaviour of stubbed requests and client requests. If a clients requests only differ in the url, there is no need to fit the stubbed requests exactly to the requests the client will actually perform - body, headers and so on might be left out. This feature comes in handy when writing unit tests where the stubbing happens directly before the assertion as part of the test. Request matching defaults to `.lenient`, so if you need full control over differentiating requests, the `.strict` option set comes in handy, other than that there are the following options to choose from: `.url`, `.httpMethod`, `.headers`, `.body`. 