### PR TITLE
Combined Stub Source Improvements

### DIFF
--- a/Sources/StubbornNetwork/Stub Sources/CombinedStubSource.swift
+++ b/Sources/StubbornNetwork/Stub Sources/CombinedStubSource.swift
@@ -17,8 +17,7 @@ struct CombinedStubSource: StubSourceProtocol {
 
     var recordMode: Bool {
         sources
-            .map { $0.recordMode }
-            .contains(true)
+            .allSatisfy { $0.recordMode }
     }
 
     func store(_ stub: RequestStub, options: RequestMatcherOptions) {

--- a/Sources/StubbornNetwork/Stub Sources/EphemeralStubSource.swift
+++ b/Sources/StubbornNetwork/Stub Sources/EphemeralStubSource.swift
@@ -15,7 +15,11 @@ class EphemeralStubSource: StubSourceProtocol {
     var stubs = [RequestStub]()
     var cachedResponses = [CachedResponse]()
 
-    var recordMode: Bool = true
+    var recordMode: Bool
+
+    init(recordMode: Bool = true) {
+        self.recordMode = recordMode
+    }
 
     func store(_ stub: RequestStub, options: RequestMatcherOptions) {
         if !hasStub(stub.request, options: options) {

--- a/Tests/StubbornNetworkTests/CombinedStubSourceTests.swift
+++ b/Tests/StubbornNetworkTests/CombinedStubSourceTests.swift
@@ -26,6 +26,33 @@ class CombinedStubSourceTests: XCTestCase {
         XCTAssertTrue(source2.hasStub(request, options: .strict))
     }
 
+    func test_combinedStubSource_isNotInRecordMode_whenOneOfItsSourcesIsNotInRecordMode() {
+        // given
+        let source1 = EphemeralStubSource(recordMode: false)
+        let source2 = EphemeralStubSource()
+        let combinedStubSource = CombinedStubSource(sources: [source1, source2])
+
+        XCTAssertFalse(combinedStubSource.recordMode)
+    }
+
+    func test_combinedStubSource_isInRecordMode_whenAllItsSourcesAreInRecordMode() {
+        // given
+        let source1 = EphemeralStubSource(recordMode: true)
+        let source2 = EphemeralStubSource(recordMode: true)
+        let combinedStubSource = CombinedStubSource(sources: [source1, source2])
+
+        XCTAssertTrue(combinedStubSource.recordMode)
+    }
+
+    func test_combinedStubSource_isNotInRecordMode_whenNoneOfItsSourcesIsInRecordMode() {
+        // given
+        let source1 = EphemeralStubSource(recordMode: false)
+        let source2 = EphemeralStubSource(recordMode: false)
+        let combinedStubSource = CombinedStubSource(sources: [source1, source2])
+
+        XCTAssertFalse(combinedStubSource.recordMode)
+    }
+
     func test_CombinedStubSource_returnsIfAnyOfItsSourcesHasAStub() throws {
         // given
         let source1 = EphemeralStubSource()
@@ -61,9 +88,19 @@ class CombinedStubSourceTests: XCTestCase {
     }
 
     static var allTests = [
-        ("test_CombinedStubSource_storesToItsSources", test_CombinedStubSource_storesToItsSources),
-        ("test_CombinedStubSource_returnsIfAnyOfItsSourcesHasAStub", test_CombinedStubSource_returnsIfAnyOfItsSourcesHasAStub),
-        ("test_CombinedStubSource_clearsAllOfItsSources", test_CombinedStubSource_clearsAllOfItsSources),
-        ("test_CombinedStubSource_clearsAllOfItsSources", test_CombinedStubSource_clearsAllOfItsSources)
+        ("test_CombinedStubSource_storesToItsSources",
+        test_CombinedStubSource_storesToItsSources),
+        ("test_CombinedStubSource_returnsIfAnyOfItsSourcesHasAStub",
+        test_CombinedStubSource_returnsIfAnyOfItsSourcesHasAStub),
+        ("test_CombinedStubSource_clearsAllOfItsSources",
+        test_CombinedStubSource_clearsAllOfItsSources),
+        ("test_CombinedStubSource_clearsAllOfItsSources",
+        test_CombinedStubSource_clearsAllOfItsSources),
+        ("test_combinedStubSource_isNotInRecordMode_whenOneOfItsSourcesIsNotInRecordMode",
+         test_combinedStubSource_isNotInRecordMode_whenOneOfItsSourcesIsNotInRecordMode),
+         ("test_combinedStubSource_isInRecordMode_whenAllItsSourcesAreInRecordMode",
+         test_combinedStubSource_isInRecordMode_whenAllItsSourcesAreInRecordMode),
+         ("test_combinedStubSource_isNotInRecordMode_whenNoneOfItsSourcesIsInRecordMode",
+         test_combinedStubSource_isNotInRecordMode_whenNoneOfItsSourcesIsInRecordMode)
     ]
 }

--- a/Tests/StubbornNetworkTests/StubbedSessionURLProtocolTests.swift
+++ b/Tests/StubbornNetworkTests/StubbedSessionURLProtocolTests.swift
@@ -121,6 +121,24 @@ class StubbedSessionURLProtocolTests: XCTestCase {
         XCTAssertEqual(recorder.recordCount, 0)
     }
 
+    func test_StubbedSessionURLProtocol_doesOnlyRecords_whenStubSourceIsInRecordMode() throws {
+        // given there is a stub for the given request
+        let url = try XCTUnwrap(URL(string: "https://elbedev.com"))
+        let task = URLSession(configuration: .ephemeral).dataTask(with: url)
+        let client = URLProtocolClientStub()
+        let recorder = StubRecorderMock()
+        let objectUnderTest = StubbedSessionURLProtocol(task: task, cachedResponse: nil, client: client, recorder: recorder)
+
+        // when StubSource is not in record mode and a request is incoming
+        let ephemeralStubSource = EphemeralStubSource(recordMode: false)
+
+        objectUnderTest.internalStubbornNetwork = StubbornNetwork(processInfo: ProcessInfo(), ephemeralStubSource)
+        objectUnderTest.startLoading()
+
+        // then it should not record
+        XCTAssertEqual(recorder.recordCount, 0)
+    }
+
     func test_StubbedSessionURLProtocol_records_whenItFindsNoMatchingStub() throws {
         // given there is no stub for the given request
         let url = try XCTUnwrap(URL(string: "https://elbedev.com"))
@@ -161,7 +179,9 @@ class StubbedSessionURLProtocolTests: XCTestCase {
          test_StubbedSessionURLProtocol_playsBackDataAndResponse_whenItFindsMatchingStub),
         ("test_StubbedSessionURLProtocol_notifiesClient_whenFinishedLoading",
          test_StubbedSessionURLProtocol_notifiesClient_whenFinishedLoading),
-        ("test_StubbedSessionURLProtocol_records_whenItFindsNoMatchingStub", test_StubbedSessionURLProtocol_records_whenItFindsNoMatchingStub)
+        ("test_StubbedSessionURLProtocol_records_whenItFindsNoMatchingStub", test_StubbedSessionURLProtocol_records_whenItFindsNoMatchingStub),
+        ("test_StubbedSessionURLProtocol_doesOnlyRecords_whenStubSourceIsInRecordMode",
+        test_StubbedSessionURLProtocol_doesOnlyRecords_whenStubSourceIsInRecordMode)
     ]
 }
 


### PR DESCRIPTION
This pull request makes sure that the `CombinedStubSource` (which is the stub source the default `StubbornNetwork` instance gets initialised with) properly aggregates the `recordMode` of its children.