### PR TITLE
make the bodymatcher less stubborn

### DIFF
--- a/Sources/StubbornNetwork/Extensions/URLRequest+Matcher.swift
+++ b/Sources/StubbornNetwork/Extensions/URLRequest+Matcher.swift
@@ -66,7 +66,17 @@ extension URLRequest {
     }
 
     private func requestBodyMatches(_ otherRequest: URLRequest) -> Bool {
-        httpBody == otherRequest.httpBody || httpBody == nil && otherRequest.httpBody == nil
+        if
+            let httpBody = httpBody,
+            let otherHttpBody = otherRequest.httpBody,
+            let JSON = try? JSONSerialization.jsonObject(with: httpBody, options: []) as? [String: Any],
+            let otherJSON = try? JSONSerialization.jsonObject(with: otherHttpBody, options: []) as? [String: Any] {
+
+            return (JSON as NSDictionary).isEqual(to: otherJSON)
+        }
+
+        return httpBody == otherRequest.httpBody
+            || httpBody == nil && otherRequest.httpBody == nil
     }
 
     private func httpMethodMatches(_ otherRequest: URLRequest) -> Bool {

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -102,8 +102,24 @@ class URLRequestMatcherTests: XCTestCase {
     }
 
     func test_unsortedUrlParameterMatches() {
+        let JSONData: [String: Any] = [
+            "z": 1,
+            "a": 0,
+            "b": 3
+        ]
+
         requestA.url = URL(string: "http://elbedev.com?a=1&b=2")
+        requestA.httpBody = try? JSONSerialization.data(withJSONObject: JSONData, options: .sortedKeys)
         requestB.url = URL(string: "http://elbedev.com?b=2&a=1")
+        requestB.httpBody = try? JSONSerialization.data(withJSONObject: JSONData, options: .prettyPrinted)
+
+        XCTAssertNotEqual(requestA.httpBody, requestB.httpBody)
+        XCTAssertTrue(requestA.matches(requestB))
+    }
+
+    func test_matchesJSONBody() {
+        requestA.url = URL(string: "http://elbedev.com")
+        requestB.url = URL(string: "http://elbedev.com")
 
         XCTAssertTrue(requestA.matches(requestB))
     }
@@ -126,7 +142,9 @@ class URLRequestMatcherTests: XCTestCase {
         ("test_customMatcher_allowsNonCustomMismatches",
         test_customMatcher_allowsNonCustomMismatches),
         ("test_unsortedUrlParameterMatches",
-        test_unsortedUrlParameterMatches)
+        test_unsortedUrlParameterMatches),
+        ("test_matchesJSONBody",
+         test_matchesJSONBody)
     ]
 
 }

--- a/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
+++ b/Tests/StubbornNetworkTests/URLRequestMatcherTests.swift
@@ -102,6 +102,13 @@ class URLRequestMatcherTests: XCTestCase {
     }
 
     func test_unsortedUrlParameterMatches() {
+        requestA.url = URL(string: "http://elbedev.com?a=1&b=2")
+        requestB.url = URL(string: "http://elbedev.com?b=2&a=1")
+
+        XCTAssertTrue(requestA.matches(requestB))
+    }
+
+    func test_matchesJSONBody() {
         let JSONData: [String: Any] = [
             "z": 1,
             "a": 0,
@@ -114,13 +121,6 @@ class URLRequestMatcherTests: XCTestCase {
         requestB.httpBody = try? JSONSerialization.data(withJSONObject: JSONData, options: .prettyPrinted)
 
         XCTAssertNotEqual(requestA.httpBody, requestB.httpBody)
-        XCTAssertTrue(requestA.matches(requestB))
-    }
-
-    func test_matchesJSONBody() {
-        requestA.url = URL(string: "http://elbedev.com")
-        requestB.url = URL(string: "http://elbedev.com")
-
         XCTAssertTrue(requestA.matches(requestB))
     }
 


### PR DESCRIPTION
We had issues when comparing the stored `httpBody` JSON with the request `httpBody`, because the keys in the JSON were sorted differently.

This PR fixes the issue by converting them to a `NSDictionary` and using `isEqual`