### PR TITLE
Move log into into a earlier stage in the PersistenceStubSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**0.1.2**
+_Body matcher comparison_
+
+This release fixes the `httpBody` comparison to address an issue when keys in JSON payload are sorted differently. 
+
 **0.1.1**
 
 _Proper CombinedStubSource_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**0.1.3**
+_Log info fixes_
+
+This release fixes the problem when one of the stubs doesn't match and the log is not printed in console.
+
 **0.1.2**
 _Body matcher comparison_
 

--- a/Sources/StubbornNetwork/Stub Sources/PersistentStubSource.swift
+++ b/Sources/StubbornNetwork/Stub Sources/PersistentStubSource.swift
@@ -58,13 +58,7 @@ class PersistentStubSource: StubSourceProtocol {
         if let index = stubs.firstIndex(where: { request.matches($0.request, options: options) }) {
             stubs.remove(at: index)
         }
-
-        if stub != nil {
-            print("Found stub for: \(request.url?.absoluteString ?? "")")
-        } else {
-            print("Did not find stub for: \(request.url?.absoluteString ?? "")")
-        }
-
+ 
         return stub
     }
 
@@ -108,6 +102,11 @@ class PersistentStubSource: StubSourceProtocol {
 
     func hasStub(_ request: URLRequest, options: RequestMatcherOptions) -> Bool {
         let stub = stubs.first { request.matches($0.request, options: options) }
+        if stub != nil {
+            print("Found stub for: \(request.url?.absoluteString ?? "")")
+        } else {
+            print("Did not find stub for: \(request.url?.absoluteString ?? "")")
+        }
         return stub != nil
     }
 }

--- a/StubbornNetwork.podspec
+++ b/StubbornNetwork.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = "StubbornNetwork"
-    spec.version      = "0.1.2"
+    spec.version      = "0.1.3"
     spec.summary      = "A Swifty and clean stubbing machine."
     spec.description  = <<-DESC
     The Stubborn Network makes your SwiftUI development more efficient and UI tests more reliable by stubbing responses of your network requests.

--- a/StubbornNetwork.podspec
+++ b/StubbornNetwork.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = "StubbornNetwork"
-    spec.version      = "0.1.1"
+    spec.version      = "0.1.2"
     spec.summary      = "A Swifty and clean stubbing machine."
     spec.description  = <<-DESC
     The Stubborn Network makes your SwiftUI development more efficient and UI tests more reliable by stubbing responses of your network requests.


### PR DESCRIPTION
When one of the stubs doesn't match (because one of the options has changed) we are not aware of this because the `print` sentence is done only when the source contains the stub (when it maches), so... we need to move these verbose info into a earlier stage.

